### PR TITLE
Publications API

### DIFF
--- a/public/members.json
+++ b/public/members.json
@@ -93,7 +93,8 @@
             "projects": [
                 "Skill Matching in Software Projects",
                 "Large Language Models in Education"
-            ]
+            ],
+            "dblp_pid": "344/0963"
         },
         {
             "first_name": "João",
@@ -140,7 +141,8 @@
                 "photo_with_background": "images/people/ana_paula_chaves_steinmacher/image_with_background.png",
                 "photo_without_background": "images/people/ana_paula_chaves_steinmacher/image_without_background.png"
             },
-            "author_name": ["Ana Steinmacher", "Ana Paula Steinmacher", "Paula Steinmacher"]
+            "author_name": ["Ana Steinmacher", "Ana Paula Steinmacher", "Paula Steinmacher"],
+            "dblp_pid": "33/2472"
         },
         {
             "first_name": "Fabio",
@@ -165,7 +167,8 @@
             "author_name": ["Fabio Santos"],
             "projects": [
                 "Skill Matching in Software Projects"
-            ]
+            ],
+            "dblp_pid": "289/0005"
         },
         {
             "first_name": "Bianca",
@@ -220,7 +223,8 @@
                 "Open Source in Education",
                 "Large Language Models in Education"
             ],
-            "author_name": ["Igor Steinmacher"]
+            "author_name": ["Igor Steinmacher"],
+            "dblp_pid": "70/3474"
         },
         {
             "first_name": "Igor",
@@ -333,7 +337,8 @@
                 "Skill Matching in Software Projects",
                 "Open Source in Education",
                 "Large Language Models in Education"
-            ]
+            ],
+            "dblp_pid": "68/5072"
         },
         {
             "first_name": "Hunter",
@@ -502,7 +507,8 @@
             "photos": {
                 "photo_with_background": "images/people/pedro_arantes/image_with_background.png",
                 "photo_without_background": "images/people/pedro_arantes/image_without_background.png"
-            }
+            },
+            "dblp_pid": "183/4888"
         },
         {
             "first_name": "Connor",

--- a/src/api/resource/articles.js
+++ b/src/api/resource/articles.js
@@ -1,57 +1,230 @@
 import Cite from 'citation-js';
 import MembersResource from '../resource/people.js';
 
-let jsonData;
+const LOCAL_BIB_ROUTE = 'papers.bib';
+const DBLP_BIB_URL = 'https://dblp.org/pid';
+const CACHE_PREFIX = 'dblp-bib-cache:';
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
-async function fetchData(bib_route) {
-    const response = await fetch(bib_route);
-    const data = await response.text();
-    jsonData = Cite.input(data);
+function getCacheKey(pid) {
+    return `${CACHE_PREFIX}${pid}`;
+}
+
+function readCache(pid) {
+    if (typeof window === 'undefined' || !window.localStorage) {
+        return null;
+    }
+
+    const rawValue = window.localStorage.getItem(getCacheKey(pid));
+
+    if (!rawValue) {
+        return null;
+    }
+
+    try {
+        const parsedValue = JSON.parse(rawValue);
+
+        if (!parsedValue.timestamp || !parsedValue.data) {
+            return null;
+        }
+
+        if (Date.now() - parsedValue.timestamp > CACHE_TTL_MS) {
+            window.localStorage.removeItem(getCacheKey(pid));
+            return null;
+        }
+
+        return parsedValue.data;
+    } catch (error) {
+        window.localStorage.removeItem(getCacheKey(pid));
+        return null;
+    }
+}
+
+function writeCache(pid, data) {
+    if (typeof window === 'undefined' || !window.localStorage) {
+        return;
+    }
+
+    const value = JSON.stringify({
+        timestamp: Date.now(),
+        data
+    });
+
+    window.localStorage.setItem(getCacheKey(pid), value);
+}
+
+async function fetchBibText(bibRoute) {
+    const response = await fetch(bibRoute);
+
+    if (!response.ok) {
+        throw new Error(`Failed to fetch bibliography from ${bibRoute}`);
+    }
+
+    return response.text();
+}
+
+function parseBibText(bibText) {
+    return Cite.input(bibText);
+}
+
+function getArticleYear(article) {
+    return article?.issued?.['date-parts']?.[0]?.[0] || 0;
+}
+
+function normalizeContainerTitle(article) {
+    if (Array.isArray(article['container-title'])) {
+        return article['container-title'].join(', ');
+    }
+
+    return article['container-title'] || article.publisher || 'Publication';
+}
+
+function normalizeAuthors(article) {
+    if (!Array.isArray(article.author)) {
+        return [];
+    }
+
+    return article.author.map((author) => ({
+        given: author.given || '',
+        family: author.family || author.literal || ''
+    }));
+}
+
+function normalizeArticle(article) {
+    return {
+        ...article,
+        DOI: article.DOI || article.doi || '',
+        URL: article.URL || article.url || '',
+        author: normalizeAuthors(article),
+        'container-title': normalizeContainerTitle(article)
+    };
+}
+
+function normalizeArticles(articles) {
+    return articles
+        .map(normalizeArticle)
+        .sort((firstArticle, secondArticle) => getArticleYear(secondArticle) - getArticleYear(firstArticle));
+}
+
+function matchesAnyAuthorName(article, names) {
+    if (!Array.isArray(article.author) || !Array.isArray(names) || names.length === 0) {
+        return false;
+    }
+
+    const normalizedNames = names.map((name) => name.toLowerCase());
+
+    return article.author.some((author) => {
+        const authorName = `${author.given || ''} ${author.family || author.literal || ''}`.trim().toLowerCase();
+        return normalizedNames.some((name) => authorName.includes(name));
+    });
+}
+
+function dedupeArticles(articles) {
+    const seenArticles = new Set();
+
+    return articles.filter((article) => {
+        const identifier = (
+            article.DOI ||
+            `${article.title || ''}:${getArticleYear(article)}:${article.author?.map((author) => `${author.given} ${author.family}`).join('|') || ''}`
+        ).toLowerCase();
+
+        if (seenArticles.has(identifier)) {
+            return false;
+        }
+
+        seenArticles.add(identifier);
+        return true;
+    });
+}
+
+async function getLocalArticles() {
+    const bibText = await fetchBibText(LOCAL_BIB_ROUTE);
+    return normalizeArticles(parseBibText(bibText));
+}
+
+async function getDblpArticlesByPid(pid) {
+    if (!pid) {
+        return [];
+    }
+
+    const cachedBibText = readCache(pid);
+
+    if (cachedBibText) {
+        return normalizeArticles(parseBibText(cachedBibText));
+    }
+
+    const bibText = await fetchBibText(`${DBLP_BIB_URL}/${pid}.bib`);
+    writeCache(pid, bibText);
+    return normalizeArticles(parseBibText(bibText));
 }
 
 const ArticlesResource = {
     async getArticlesByAuthor(names) {
-        await fetchData('../papers.bib');
+        const localArticles = await getLocalArticles();
+        return localArticles.filter((article) => matchesAnyAuthorName(article, names));
+    },
 
-        return jsonData.filter(article => {
-            
-            if (!article.author) {
-                return false;
+    async getArticlesByDblpPid(pid) {
+        return getDblpArticlesByPid(pid);
+    },
+
+    async getArticlesForMember(member) {
+        if (member?.dblpPid) {
+            try {
+                return await getDblpArticlesByPid(member.dblpPid);
+            } catch (error) {
+                console.warn(`Falling back to local bibliography for ${member.firstName} ${member.lastName}.`, error);
             }
+        }
 
-            return article.author.some(author => {
-                const authorStr = Object.values(author).join(' ').toLowerCase();
-                return names.some(name => authorStr.includes(name.toLowerCase()));
-            });
-        });
+        return this.getArticlesByAuthor(member?.author_name || []);
     },
 
     async getAllArticles() {
-        await fetchData('papers.bib');
+        const members = await MembersResource.getMembers();
+        const membersWithDblpPid = members.filter((member) => member.dblpPid);
 
-        return jsonData.sort((a, b) => {
-            const yearA = a.issued['date-parts'][0][0];
-            const yearB = b.issued['date-parts'][0][0];
-            return yearB - yearA;
-        });
+        if (membersWithDblpPid.length === 0) {
+            return getLocalArticles();
+        }
+
+        const articleCollections = await Promise.all(
+            membersWithDblpPid.map(async (member) => {
+                try {
+                    return await getDblpArticlesByPid(member.dblpPid);
+                } catch (error) {
+                    console.warn(`Skipping DBLP publications for ${member.firstName} ${member.lastName}.`, error);
+                    return [];
+                }
+            })
+        );
+
+        const mergedArticles = dedupeArticles(articleCollections.flat());
+
+        if (mergedArticles.length > 0) {
+            return mergedArticles.sort((firstArticle, secondArticle) => getArticleYear(secondArticle) - getArticleYear(firstArticle));
+        }
+
+        return getLocalArticles();
     },
 
     async getArticlesByYear(year) {
-        await fetchData();
-    
-        const filteredArticles = jsonData.filter(article => {
-            return article.issued['date-parts'][0][0] === year;
-        });
-    
-        const articlesWithAuthors = await Promise.all(filteredArticles.map(async article => {
-            const authorNames = article.author ? article.author.map(author => Object.values(author).join(' ')) : [];
-            const nau_authors = await MembersResource.getMemberByAuthorName(authorNames);
-            return { ...article, nau_authors };
-        }));
-    
-        return articlesWithAuthors;
-    },
+        const allArticles = await this.getAllArticles();
 
+        const filteredArticles = allArticles.filter((article) => {
+            return getArticleYear(article) === year;
+        });
+
+        const articlesWithAuthors = await Promise.all(filteredArticles.map(async (article) => {
+            const authorNames = article.author
+                ? article.author.map((author) => `${author.given} ${author.family}`.trim())
+                : [];
+            const nauAuthors = await MembersResource.getMemberByAuthorName(authorNames);
+            return { ...article, nau_authors: nauAuthors };
+        }));
+
+        return articlesWithAuthors;
+    }
 };
 
 export default ArticlesResource;

--- a/src/api/resource/people.js
+++ b/src/api/resource/people.js
@@ -8,7 +8,8 @@ const MembersResource = {
             role: member.role,
             photos: member.photos,
             contacts: member.contacts,
-            author_name: member.author_name
+            author_name: member.author_name,
+            dblpPid: member.dblp_pid || ''
         }));
 
         members.sort((a, b) => {
@@ -38,7 +39,8 @@ const MembersResource = {
             role: member.role,
             photos: member.photos,
             contacts: member.contacts,
-            author_name: member.author_name
+            author_name: member.author_name,
+            dblpPid: member.dblp_pid || ''
         }));
 
         members.sort((a, b) => {
@@ -62,7 +64,8 @@ const MembersResource = {
             contacts: member.contacts,
             description: member.description,
             research_keywords: member.research_keywords,
-            highlighted_publications: member.highlighted_publications
+            highlighted_publications: member.highlighted_publications,
+            dblpPid: member.dblp_pid || ''
         } : null;
         
         return Promise.resolve(memberData);
@@ -83,7 +86,8 @@ const MembersResource = {
             description: member.description,
             research_keywords: member.research_keywords,
             highlighted_publications: member.highlighted_publications,
-            author_name: member.author_name
+            author_name: member.author_name,
+            dblpPid: member.dblp_pid || ''
         } : null;
 
         return Promise.resolve(memberData);

--- a/src/components/cards/PublishedPaperCard.vue
+++ b/src/components/cards/PublishedPaperCard.vue
@@ -12,8 +12,8 @@
         <i>{{ journal }}</i>
         </div>
 
-        <a class = "doi" :href="`https://doi.org/${doi}`">
-            <strong> DOI </strong> 
+        <a v-if="paperLink" class = "doi" :href="paperLink" target="_blank" rel="noopener noreferrer">
+            <strong> {{ linkLabel }} </strong> 
         </a>
 
     </div>
@@ -44,6 +44,18 @@ export default {
     },
 
     computed: {
+        paperLink() {
+            if (this.doi) {
+                return `https://doi.org/${this.doi}`;
+            }
+
+            return this.url || '';
+        },
+
+        linkLabel() {
+            return this.doi ? 'DOI' : 'Link';
+        },
+
         processedAuthors() {
             if (!this.authors) {
                 return ' ';

--- a/src/views/Publications.vue
+++ b/src/views/Publications.vue
@@ -5,7 +5,7 @@
         <div class = "published_paper_container">
             <PublishedPaperCard
                 v-for="paper in publishedPapers"
-                :key="paper.doi"
+                :key="paper.DOI || `${paper.title}-${paper.issued['date-parts'][0][0]}`"
                 :title="paper.title"
                 :journal="paper['container-title']"
                 :year="paper.issued['date-parts'][0][0]"

--- a/src/views/Publications.vue
+++ b/src/views/Publications.vue
@@ -2,13 +2,30 @@
     <div class = "project_container">
         <p class = "title" :style="{ color: primary_color }"> PUBLICATIONS </p>
 
-        <div class = "published_paper_container">
+        <div class = "search_container">
+            <input 
+                type = "text" 
+                v-model = "inputTerm" 
+                placeholder = "Search by title, author, year, DOI, or venue..." 
+                class = "search_bar"
+            >
+            
+            <button @click="inputTerm ? resetSearch() : search" class="button search_button">
+                <img :src="inputTerm ? '/icons/remove.png' : '/icons/search.png'" :alt="inputTerm ? 'Clean' : 'Search'" class="button-icon">
+            </button>
+        </div>
+
+        <div v-if="!filteredPapers.length" class="empty_state">
+            No publications match the current search.
+        </div>
+
+        <div v-else class = "published_paper_container">
             <PublishedPaperCard
-                v-for="paper in publishedPapers"
-                :key="paper.DOI || `${paper.title}-${paper.issued['date-parts'][0][0]}`"
+                v-for="paper in filteredPapers"
+                :key="paper.DOI || `${paper.title}-${paper.issued?.['date-parts']?.[0]?.[0] || 'unknown'}`"
                 :title="paper.title"
                 :journal="paper['container-title']"
-                :year="paper.issued['date-parts'][0][0]"
+                :year="paper.issued?.['date-parts']?.[0]?.[0]"
                 :url="paper.URL"
                 :doi="paper.DOI"
                 :authors="paper.author"
@@ -31,7 +48,9 @@ export default {
         return {
             primary_color: research_lab.color_pallete.primary_color,
             secundary_color: research_lab.color_pallete.secundary_color,
-            publishedPapers: []
+            publishedPapers: [],
+            searchTerm: '',
+            inputTerm: ''
         };
     },
   
@@ -45,11 +64,61 @@ export default {
             .catch((error) => {
                 console.error('An error occurred:', error);
             });
+        },
+
+        search() {
+            if (this.inputTerm) {
+                this.searchTerm = this.inputTerm;
+            }
+        },
+
+        resetSearch() {
+            this.inputTerm = '';
+            this.searchTerm = '';
+        },
+
+        getPaperSearchText(paper) {
+            const authors = Array.isArray(paper.author)
+                ? paper.author.map((author) => `${author.given || ''} ${author.family || ''}`.trim()).join(' ')
+                : '';
+            const year = paper.issued?.['date-parts']?.[0]?.[0] || '';
+
+            return [
+                paper.title,
+                paper['container-title'],
+                paper.DOI,
+                paper.URL,
+                authors,
+                `${year}`
+            ]
+                .filter(Boolean)
+                .join(' ')
+                .toLowerCase();
         }
     },
 
     created() {
         this.getAllArticles();
+    },
+
+    watch: {
+        inputTerm(newInputTerm) {
+            this.searchTerm = newInputTerm;
+        }
+    },
+
+    computed: {
+        filteredPapers() {
+            const lowerCaseSearchTerm = this.searchTerm.toLowerCase().trim();
+
+            if (!lowerCaseSearchTerm) {
+                return this.publishedPapers;
+            }
+
+            return this.publishedPapers.filter((paper) => {
+                return this.getPaperSearchText(paper).includes(lowerCaseSearchTerm);
+            });
+        }
     },
 
     components: {
@@ -103,6 +172,48 @@ export default {
     margin-bottom: 10px;
     margin-top: 10px;
     max-width: 825px;
+}
+
+.search_bar {
+    max-width: max(80vw);
+    border-radius: 30px;
+    padding-left: 15px;
+    height: 50px;
+    width: 500px;
+    font-size: 18px;
+    border: 1px solid #6E6E6E;
+}
+
+.button-icon {
+    width: 24px;
+    height: 24px;
+}
+
+.search_container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    max-width: 80vw;
+    margin: 0 auto;
+    position: relative;
+}
+
+.search_button {
+    border: 1px solid #6E6E6E;
+    position: absolute;
+    right: 0;
+    top: 0;
+    height: 100%;
+    width: 50px;
+    border-radius: 30px 30px 30px 30px;
+    padding: 0;
+    background-color: var(--primary-color)
+}
+
+.empty_state {
+    margin-top: 20px;
+    font-size: 24px;
 }
 
 .title {

--- a/src/views/Researcher.vue
+++ b/src/views/Researcher.vue
@@ -100,7 +100,7 @@
         <div class = "published_paper_container">
             <PublishedPaperCard
                 v-for="paper in paginatedPapers"
-                :key="paper.doi"
+                :key="paper.DOI || `${paper.title}-${paper.issued['date-parts'][0][0]}`"
                 :title="paper.title"
                 :journal="paper['container-title']"
                 :year="paper.issued['date-parts'][0][0]"
@@ -197,6 +197,7 @@ export default  {
             currentPage: 1,
             papersPerPage: 6,
             author_name: [],
+            dblpPid: '',
         };
     },
 
@@ -213,6 +214,7 @@ export default  {
                 this.research_keywords = result.research_keywords;
                 this.role = result.role;
                 this.author_name = result.author_name;
+                this.dblpPid = result.dblpPid;
                 
                 this.getPapers();
             })
@@ -223,7 +225,12 @@ export default  {
 
         getPapers() {
             ArticlesResource
-            .getArticlesByAuthor(this.author_name)
+            .getArticlesForMember({
+                firstName: this.first_name,
+                lastName: this.last_name,
+                author_name: this.author_name,
+                dblpPid: this.dblpPid
+            })
             .then((result) => {
                 this.published_papers = result;
             })


### PR DESCRIPTION
Fixes feature #5 and #2 on issue tracker.

Publications are automatically updated via dblp.org's APIs using a caching system so that users don't hit the API every time they refresh the page. The system looks for a dblp_pid for each member in members.json, which is the several numbers at the end of a author's page on dblp.org. If it is not present, it uses papers.bib as a fallback. I also added a search bar that can search multiple fields using the logic from the people page on the website.