### PR TITLE
Backend Admin Portal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-# Logs
 logs
 *.log
 npm-debug.log*
@@ -13,8 +12,10 @@ dist
 dist-ssr
 coverage
 *.local
+.env
+.env.*
+!.env.example
 
-# Editor directories and files
 .vscode/*
 !.vscode/extensions.json
 .idea

--- a/README.md
+++ b/README.md
@@ -1,6 +1,31 @@
 # reshapelab.github.io
 Project Page
 
+## Supabase admin prototype
+
+This repo now includes a Supabase-backed admin prototype for:
+
+1. Admin login at `/admin/login`
+2. News CRUD at `/admin/news`
+3. People CRUD at `/admin/people`
+4. Editing research keywords, DBLP PIDs, and profile metadata for people
+
+### Setup
+
+1. Create a Supabase project.
+2. Run the SQL in [supabase/schema.sql](./supabase/schema.sql) in the Supabase SQL editor.
+3. Copy [.env.example](./.env.example) to `.env` and fill in:
+   - `VITE_SUPABASE_URL`
+   - `VITE_SUPABASE_ANON_KEY`
+4. In Supabase Auth, enable Email/Password login.
+5. Create your first user in Supabase Auth.
+6. In the `profiles` table, set that user's `is_admin` to `true`.
+
+### Notes
+
+- The public site still falls back to the local JSON files when Supabase is not configured or unavailable.
+- For this prototype, news images and profile images are still stored as string paths. Storage upload flows can be added next.
+
 Steps to deploy to Github Pages
 
 To recommit new changes and push up to the remote repository:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # reshapelab.github.io
 Project Page
 
-## Supabase admin prototype
+## Supabase Admin
 
-This repo now includes a Supabase-backed admin prototype for:
+This repo now includes a Supabase-backed admin portal for:
 
 1. Admin login at `/admin/login`
 2. News CRUD at `/admin/news`
@@ -14,28 +14,17 @@ This repo now includes a Supabase-backed admin prototype for:
 
 1. Create a Supabase project.
 2. Run the SQL in [supabase/schema.sql](./supabase/schema.sql) in the Supabase SQL editor.
-3. Copy [.env.example](./.env.example) to `.env` and fill in:
-   - `VITE_SUPABASE_URL`
-   - `VITE_SUPABASE_ANON_KEY`
-4. In Supabase Auth, enable Email/Password login.
+3. Create a `.env` file and fill in these values after the "=" using your Supabase API keys.
+   - `VITE_SUPABASE_URL=`
+   - `VITE_SUPABASE_ANON_KEY=`
+   - `SUPABASE_SERVICE_ROLE_KEY=`
+4. In Supabase Auth, enable Email/Password login (it may already be enabled).
 5. Create your first user in Supabase Auth.
-6. In the `profiles` table, set that user's `is_admin` to `true`.
+6. In the `profiles` table, set that user's `is_admin` to `true`. This user may now use the admin portal for the website.
 
 ### Notes
 
-- The public site still falls back to the local JSON files when Supabase is not configured or unavailable.
-- For this prototype, news images and profile images are still stored as string paths. Storage upload flows can be added next.
-
-Steps to deploy to Github Pages
-
-To recommit new changes and push up to the remote repository:
-
-1. On remote repository delete the "gh-pages" branch. 
-
-2. In you local repository run this command: npm run build
-
-3. git add dist -f
-
-4. git commit -m [your commit message here]
-
-5. git subtree push --prefix dist origin gh-pages
+- The public site still falls back to the local .json files when Supabase is not configured or unavailable.
+- News images and profile images are still stored as string paths.
+- The current .json and image data can be uploaded to Supabase at anytime (as long as .env is configured) using `npm run import:supabase`
+- Test this project by first using `npm i` then `npm run dev`

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.0",
             "dependencies": {
                 "@element-plus/icons-vue": "^2.1.0",
+                "@supabase/supabase-js": "^2.103.0",
                 "@vuelidate/core": "^2.0.2",
                 "@vuelidate/validators": "^2.0.2",
                 "axios": "^1.6.0",
@@ -799,6 +800,92 @@
                 }
             }
         },
+        "node_modules/@supabase/auth-js": {
+            "version": "2.103.0",
+            "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.103.0.tgz",
+            "integrity": "sha512-6zAanO6c+6gpHOlt5Lb9TlBBkJdZiUWkWCJKAxzkywBDcwaHlLJKXnjQGX6GyVCyKRR1e7sTq4re/yRTH6U/9A==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@supabase/functions-js": {
+            "version": "2.103.0",
+            "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.103.0.tgz",
+            "integrity": "sha512-YrneV2NjskUkkmkZ2Jt2n3elBgbWzV4Y1M9MM370z2Zd5ZPFqFbY8KIoPwuNjtAGE9YrpKBxnbZqeF07BiN9Og==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@supabase/phoenix": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+            "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+            "license": "MIT"
+        },
+        "node_modules/@supabase/postgrest-js": {
+            "version": "2.103.0",
+            "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.103.0.tgz",
+            "integrity": "sha512-rC3sRxYdPZymkp2CZR1MiNQgbOleD01bGsW8VxEKRR5nMkLZ1NgAS1QTQf78Wh30czFyk505ZYr9Od8/mWT2TA==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@supabase/realtime-js": {
+            "version": "2.103.0",
+            "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.103.0.tgz",
+            "integrity": "sha512-gcPtXzZ6izyyBVf2of7K3dEt8CScPJn8VcSlQq6oWL9QoE1kqfQl0oFrOMHd5qrcADewxI7OxxosLB8W4XqtIQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@supabase/phoenix": "^0.4.0",
+                "@types/ws": "^8.18.1",
+                "tslib": "2.8.1",
+                "ws": "^8.18.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@supabase/storage-js": {
+            "version": "2.103.0",
+            "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.103.0.tgz",
+            "integrity": "sha512-DHmlvdAXwtOmZNbkIZi4lkobPR3XjIzoOgzoz5duMf6G+sDeY015YrzMJCnqdccuYr7X5x4yYuSwF//RoN2dvQ==",
+            "license": "MIT",
+            "dependencies": {
+                "iceberg-js": "^0.8.1",
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@supabase/supabase-js": {
+            "version": "2.103.0",
+            "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.103.0.tgz",
+            "integrity": "sha512-j/6q5+LtXbR/YOLSLhy7Na74RD1cV2v+KwIIuuqMEjk1JpLEEyu0ynwDHpGoxMncDQl+R5FogaVqZm+85lZvtw==",
+            "license": "MIT",
+            "dependencies": {
+                "@supabase/auth-js": "2.103.0",
+                "@supabase/functions-js": "2.103.0",
+                "@supabase/postgrest-js": "2.103.0",
+                "@supabase/realtime-js": "2.103.0",
+                "@supabase/storage-js": "2.103.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/@types/eslint": {
             "version": "8.44.7",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.7.tgz",
@@ -849,8 +936,7 @@
         "node_modules/@types/node": {
             "version": "20.5.7",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
-            "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==",
-            "dev": true
+            "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA=="
         },
         "node_modules/@types/sinonjs__fake-timers": {
             "version": "8.1.1",
@@ -898,6 +984,15 @@
             "version": "0.0.16",
             "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.16.tgz",
             "integrity": "sha512-oh8q2Zc32S6gd/j50GowEjKLoOVOwHP/bWVjKJInBwQqdOYMdPrf1oVlelTlyfFK3CKxL1uahMDAr+vy8T7yMQ=="
+        },
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/yauzl": {
             "version": "2.10.0",
@@ -3138,6 +3233,15 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/iceberg-js": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+            "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -4673,10 +4777,10 @@
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
         "node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-            "dev": true
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
         },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
@@ -5174,6 +5278,27 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true
+        },
+        "node_modules/ws": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/yauzl": {
             "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "dev": "vite",
         "build": "vite build",
         "preview": "vite preview",
+        "import:supabase": "node scripts/import-supabase-content.mjs",
         "test": "npx cypress run",
         "coverage": "jest --coverage --coveragePath=coverage"
     },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     },
     "dependencies": {
         "@element-plus/icons-vue": "^2.1.0",
+        "@supabase/supabase-js": "^2.103.0",
         "@vuelidate/core": "^2.0.2",
         "@vuelidate/validators": "^2.0.2",
         "axios": "^1.6.0",

--- a/public/members.json
+++ b/public/members.json
@@ -22,7 +22,8 @@
             "projects": [
                 "Open Source in Education",
                 "Large Language Models in Education"
-            ]
+            ],
+            "dblp_pid": "221/1638"
         },
         {
             "first_name": "Katia Romero",
@@ -44,7 +45,8 @@
             "author_name": ["Katia Romero Felizardo", "Katia Felizardo", "Romero Felizardo", "Katia R. Felizardo"],
             "projects": [
                 "Large Language Models in Education"
-            ]
+            ],
+            "dblp_pid": "53/8384"
         },
         {
             "first_name": "Daniel",
@@ -69,7 +71,8 @@
             "projects": [
                 "Open Source in Education",
                 "Large Language Models in Education"
-            ]
+            ],
+            "dblp_pid": "87/1273"
         },
         {
             "first_name": "Jacob",
@@ -119,7 +122,8 @@
             "projects": [
                 "Open Source in Education",
                 "Large Language Models in Education"
-            ]
+            ],
+            "dblp_pid": "221/1636"
         },
         {
             "first_name": "Ana Paula",
@@ -191,7 +195,8 @@
             "author_name": ["Bianca Trinkenreich"],
             "projects": [
                 "Diversity and Inclusion in Open Source"
-            ]
+            ],
+            "dblp_pid": "166/2138"
         },
         {
             "first_name": "Igor",
@@ -248,10 +253,11 @@
             "projects": [
                 "Diversity and Inclusion in Open Source",
                 "Skill Matching in Software Projects"
-            ]
+            ],
+            "dblp_pid": "06/10439"
         },
         {
-            "first_name": "Marieli",
+            "first_name": "Mairieli",
             "last_name": "Wessel",
             "role": "Alumni (PhD)",
             "photos": {
@@ -268,11 +274,12 @@
                 "Empirical Software Engineering",
                 "Mining Software Repositories"
             ],
-            "author_name": ["Marieli Wessel"]
+            "author_name": ["Mairieli Wessel"],
+            "dblp_pid": "205/9369"
         },
         {
             "first_name": "Italo",
-            "last_name": "Santo",
+            "last_name": "Santos",
             "role": "Alumni (PhD)",
             "photos": {
                 "photo_with_background": "images/people/italo_santo/image_with_background.png",
@@ -288,12 +295,13 @@
                 "Gamification in SE",
                 "Empirical software engineering"
             ],
-            "author_name": ["Italo Santo"],
+            "author_name": ["Italo Santos", "Ítalo Santos"],
             "projects": [
                 "Diversity and Inclusion in Open Source",
                 "Skill Matching in Software Projects",
                 "Open Source in Education"
-            ]
+            ],
+            "dblp_pid": "203/0063"
         },
         {
             "first_name": "Marco",
@@ -353,14 +361,16 @@
             "research_keywords": [ 
                 "Large Language Models",
                 "Retrieval Augmented Generation",
-                " Mining Software Repositories",
+                "Mining Software Repositories",
                 "AI-Assisted Software Engineering",
                 "OSS Communities"
             ],
             "photos": {
                 "photo_with_background": "images/people/hunter_beach/image_with_background.png",
                 "photo_without_background": "images/people/hunter_beach/image_without_background.png"
-            }
+            },
+            "author_name": ["Hunter Beach"],
+            "dblp_pid": "410/7532"
         },
         {
             "first_name": "Peter",
@@ -381,7 +391,9 @@
             "photos": {
                 "photo_with_background": "images/people/user_icon.png",
                 "photo_without_background": "images/people/user_icon.png"
-            }
+            },
+            "author_name": ["Peter Hilbert"],
+            "dblp_pid": "410/1459"
         },
         {
             "first_name": "Misan",
@@ -400,7 +412,9 @@
             "photos": {
                 "photo_with_background": "images/people/misan_etchie/image_with_background.png",
                 "photo_without_background": "images/people/misan_etchie/image_without_background.png"
-            }
+            },
+            "author_name": ["Misan Etchie", "Misan Paul Etchie"],
+            "dblp_pid": "410/7084"
         },
         {
             "first_name": "Pawan",
@@ -424,7 +438,9 @@
             "photos": {
                 "photo_with_background": "images/people/pawan/image_with_background.png",
                 "photo_without_background": "images/people/pawan/image_without_background.png"
-            }
+            },
+            "author_name": ["Pawan Acharya"],
+            "dblp_pid": "398/3879"
         },
         {
             "first_name": "Filipe",
@@ -444,7 +460,9 @@
             "photos": {
                 "photo_with_background": "images/people/filipe_verri/image_with_background.png",
                 "photo_without_background": "images/people/filipe_verri/image_without_background.png"
-            }
+            },
+            "author_name": ["Filipe Verri", "Filipe A. N. Verri", "Filipe Alves Neto Verri"],
+            "dblp_pid": "174/2784"
         },
         {
             "first_name": "Genildo",
@@ -467,7 +485,9 @@
             "photos": {
                 "photo_with_background": "images/people/genildo/image_with_background.png",
                 "photo_without_background": "images/people/genildo/image_without_background.png"
-            }
+            },
+            "author_name": ["Genildo Gomes", "Genildo Junior"],
+            "dblp_pid": "283/4200"
         },
         {
             "first_name": "Maria",
@@ -488,7 +508,9 @@
             "photos": {
                 "photo_with_background": "images/people/maria_meireles/image_with_background.png",
                 "photo_without_background": "images/people/maria_meireles/image_without_background.png"
-            }
+            },
+            "author_name": ["Maria Meireles", "Maria A. C. Meireles", "Maria Alcimar Meireles", "Maria Alcimar Costa Meireles"],
+            "dblp_pid": "266/3551"
         },
         {
             "first_name": "Pedro",
@@ -508,7 +530,7 @@
                 "photo_with_background": "images/people/pedro_arantes/image_with_background.png",
                 "photo_without_background": "images/people/pedro_arantes/image_without_background.png"
             },
-            "dblp_pid": "183/4888"
+            "author_name": ["Pedro Oliveira", "Pedro Rodrigues Arantes de Oliveira"]
         },
         {
             "first_name": "Connor",
@@ -527,7 +549,8 @@
             "photos": {
                 "photo_with_background": "images/people/connor/image_with_background.png",
                 "photo_without_background": "images/people/connor/image_without_background.png"
-            }
+            },
+            "author_name": ["Connor Aiton"]
         },
         {
             "first_name": "Jadyn",
@@ -546,7 +569,8 @@
             "photos": {
                 "photo_with_background": "images/people/jadyn/image_with_background.png",
                 "photo_without_background": "images/people/jadyn/image_without_background.png"
-            }
+            },
+            "author_name": ["Jadyn Calhoun"]
         },
         {
             "first_name": "Karissa",
@@ -566,7 +590,8 @@
             "photos": {
                 "photo_with_background": "images/people/karissa/image_with_background.png",
                 "photo_without_background": "images/people/karissa/image_without_background.png"
-            }
+            },
+            "author_name": ["Karissa Smallwood"]
         },
         {
             "first_name": "Wellynton",
@@ -587,7 +612,8 @@
                 "photo_with_background": "images/people/wellynton/image_with_background.png",
                 "photo_without_background": "images/people/wellynton/image_without_background.png"
             },
-            "author_name": ["Wellynton Diniz"]
+            "author_name": ["Wellynton Diniz"],
+            "dblp_pid": "388/4060"
         },
         {
             "first_name": "Brenda",
@@ -605,7 +631,7 @@
             "research_keywords": [
                 "Biodiversity", "Environmental Education", "Waste Water Treatment", "Environmental Monitoring"
             ],
-            "author_name": ["Brenda Diniz"]   
+            "author_name": ["Brenda Diniz"]
         },
         {
             "first_name": "Riley",
@@ -624,7 +650,8 @@
             "photos": {
                 "photo_with_background": "images/people/riley_burke/image_with_background.png",
                 "photo_without_background": "images/people/riley_burke/image_without_background.png"
-            }
+            },
+            "author_name": ["Riley Burke"]
         },
         {
             "first_name": "Andrew",
@@ -634,7 +661,6 @@
                 "email": "ajs2583@nau.edu",
                 "github": "ajs2583"
             },
-        
             "description": "I am a senior Computer Science student with minors in Cybersecurity and Informatics! I'm particularly drawn to automation, DevOps, and AI research, where I can combine my love for problem-solving with efficient, scalable solutions. ",
             "research_keywords": [ 
                 "Machine Learning", 
@@ -644,7 +670,8 @@
             "photos": {
                 "photo_with_background": "images/people/andrew_sliva/image_with_background.png",
                 "photo_without_background": "images/people/andrew_sliva/image_without_background.png"
-            }
+            },
+            "author_name": ["Andrew Sliva"]
         },
         {
             "first_name": "Noah",
@@ -664,7 +691,8 @@
             "photos": {
                 "photo_with_background": "images/people/noah_verdugo/image_with_background.png",
                 "photo_without_background": "images/people/noah_verdugo/image_without_background.png"
-            }
+            },
+            "author_name": ["Noah Verdugo"]
         },
         {
             "first_name": "Sam",
@@ -684,7 +712,8 @@
             "photos": {
                 "photo_with_background": "images/people/sam_utzinger/image_with_background.png",
                 "photo_without_background": "images/people/sam_utzinger/image_without_background.png"
-            }
+            },
+            "author_name": ["Sam Utzinger"]
         }
     ]
 }

--- a/scripts/import-supabase-content.mjs
+++ b/scripts/import-supabase-content.mjs
@@ -1,0 +1,298 @@
+import { createClient } from '@supabase/supabase-js';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+const publicDir = path.join(projectRoot, 'public');
+const newsBucket = 'news-images';
+const peopleBucket = 'people-images';
+
+function loadEnvFile() {
+    const envPath = path.join(projectRoot, '.env');
+
+    return fs.readFile(envPath, 'utf8')
+        .then((contents) => {
+            contents.split(/\r?\n/).forEach((line) => {
+                const trimmed = line.trim();
+
+                if (!trimmed || trimmed.startsWith('#')) {
+                    return;
+                }
+
+                const equalsIndex = trimmed.indexOf('=');
+
+                if (equalsIndex < 0) {
+                    return;
+                }
+
+                const key = trimmed.slice(0, equalsIndex).trim();
+                const rawValue = trimmed.slice(equalsIndex + 1).trim();
+                const unwrappedValue = rawValue.replace(/^['"]|['"]$/g, '');
+
+                if (!(key in process.env)) {
+                    process.env[key] = unwrappedValue;
+                }
+            });
+        })
+        .catch(() => {
+            // The project can still run if the caller provided env vars directly.
+        });
+}
+
+function getContentType(filePath) {
+    const extension = path.extname(filePath).toLowerCase();
+
+    switch (extension) {
+    case '.png':
+        return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+        return 'image/jpeg';
+    case '.gif':
+        return 'image/gif';
+    case '.webp':
+        return 'image/webp';
+    case '.svg':
+        return 'image/svg+xml';
+    default:
+        return 'application/octet-stream';
+    }
+}
+
+function toPosixPath(filePath) {
+    return filePath.split(path.sep).join('/');
+}
+
+function getLocalAssetPath(relativePath) {
+    return path.join(publicDir, relativePath.replace(/^\/+/, ''));
+}
+
+function isLocalAssetPath(value, prefix) {
+    return typeof value === 'string' && value.replace(/^(\.\.\/|\.\/)+/, '').startsWith(prefix);
+}
+
+async function readJson(relativePath) {
+    const contents = await fs.readFile(path.join(projectRoot, relativePath), 'utf8');
+    return JSON.parse(contents);
+}
+
+async function ensureBucket(supabase, bucketName) {
+    const { error } = await supabase.storage.createBucket(bucketName, {
+        public: true
+    });
+
+    if (error && !/already exists/i.test(error.message || '')) {
+        throw error;
+    }
+}
+
+async function uploadAssetIfNeeded(supabase, bucketName, sourcePath, storagePath, cache = new Map()) {
+    const cacheKey = `${bucketName}:${sourcePath}`;
+
+    if (cache.has(cacheKey)) {
+        return cache.get(cacheKey);
+    }
+
+    const fileBuffer = await fs.readFile(getLocalAssetPath(sourcePath));
+    const normalizedStoragePath = toPosixPath(storagePath);
+
+    const { error: uploadError } = await supabase.storage
+        .from(bucketName)
+        .upload(normalizedStoragePath, fileBuffer, {
+            upsert: true,
+            cacheControl: '3600',
+            contentType: getContentType(sourcePath)
+        });
+
+    if (uploadError) {
+        throw uploadError;
+    }
+
+    const {
+        data: { publicUrl }
+    } = supabase.storage.from(bucketName).getPublicUrl(normalizedStoragePath);
+
+    const result = {
+        storagePath: normalizedStoragePath,
+        publicUrl
+    };
+
+    cache.set(cacheKey, result);
+    return result;
+}
+
+function collectDescriptionImagePaths(description) {
+    const matches = [];
+    const pattern = /<img\b[^>]*\bsrc=['"]([^'"]+)['"][^>]*>/gi;
+    let match = pattern.exec(description || '');
+
+    while (match) {
+        matches.push(match[1]);
+        match = pattern.exec(description || '');
+    }
+
+    return matches;
+}
+
+async function importNews(supabase) {
+    const { posts } = await readJson('public/posts.json');
+    const uploadCache = new Map();
+    const assetMap = new Map();
+
+    for (const post of posts) {
+        const candidatePaths = [post.image, ...collectDescriptionImagePaths(post.description)];
+
+        for (const candidatePath of candidatePaths) {
+            if (!isLocalAssetPath(candidatePath, 'images/posts/')) {
+                continue;
+            }
+
+            const normalizedSourcePath = candidatePath.replace(/^(\.\.\/)+/, '');
+            const storagePath = normalizedSourcePath.replace(/^images\/posts\//, '');
+            const uploadedAsset = await uploadAssetIfNeeded(
+                supabase,
+                newsBucket,
+                normalizedSourcePath,
+                storagePath,
+                uploadCache
+            );
+
+            assetMap.set(candidatePath, uploadedAsset);
+            assetMap.set(normalizedSourcePath, uploadedAsset);
+        }
+    }
+
+    const payload = posts.map((post) => {
+        const primaryImage = assetMap.get(post.image);
+        let description = post.description || '';
+
+        assetMap.forEach((asset, sourcePath) => {
+            if (!sourcePath) {
+                return;
+            }
+
+            const escapedSourcePath = sourcePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            description = description.replace(new RegExp(escapedSourcePath, 'g'), asset.publicUrl);
+        });
+
+        return {
+            id: post.id,
+            title: post.title,
+            date: post.date,
+            person: post.person || [],
+            tag: post.tag || '',
+            image: primaryImage ? `${newsBucket}/${primaryImage.storagePath}` : post.image || '',
+            description,
+            published: post.published !== false,
+            sort_order: typeof post.sort_order === 'number' ? post.sort_order : null
+        };
+    });
+
+    const { error } = await supabase.from('news_posts').upsert(payload, {
+        onConflict: 'id'
+    });
+
+    if (error) {
+        throw error;
+    }
+
+    return {
+        postsImported: payload.length,
+        newsImagesUploaded: uploadCache.size
+    };
+}
+
+async function importPeople(supabase) {
+    const { members } = await readJson('public/members.json');
+    const uploadCache = new Map();
+
+    const payload = [];
+
+    for (const member of members) {
+        const photos = { ...(member.photos || {}) };
+
+        for (const [photoKey, photoPath] of Object.entries(photos)) {
+            if (!isLocalAssetPath(photoPath, 'images/people/')) {
+                continue;
+            }
+
+            const storagePath = photoPath.replace(/^images\/people\//, '');
+            const uploadedAsset = await uploadAssetIfNeeded(
+                supabase,
+                peopleBucket,
+                photoPath,
+                storagePath,
+                uploadCache
+            );
+
+            photos[photoKey] = `${peopleBucket}/${uploadedAsset.storagePath}`;
+        }
+
+        payload.push({
+            slug: member.slug || `${member.first_name || ''} ${member.last_name || ''}`.trim().replace(/ /g, '-'),
+            first_name: member.first_name,
+            last_name: member.last_name,
+            role: member.role,
+            description: member.description || '',
+            contacts: member.contacts || {},
+            photos,
+            research_keywords: member.research_keywords || [],
+            highlighted_publications: member.highlighted_publications || [],
+            author_name: member.author_name || [],
+            dblp_pid: member.dblp_pid || '',
+            projects: member.projects || [],
+            is_active: member.is_active !== false
+        });
+    }
+
+    const { error } = await supabase.from('people_profiles').upsert(payload, {
+        onConflict: 'slug'
+    });
+
+    if (error) {
+        throw error;
+    }
+
+    return {
+        peopleImported: payload.length,
+        peopleImagesUploaded: uploadCache.size
+    };
+}
+
+async function main() {
+    await loadEnvFile();
+
+    const supabaseUrl = process.env.VITE_SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    if (!supabaseUrl || !serviceRoleKey) {
+        throw new Error(
+            'Missing VITE_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY. Add them to .env before running the import.'
+        );
+    }
+
+    const supabase = createClient(supabaseUrl, serviceRoleKey, {
+        auth: {
+            persistSession: false,
+            autoRefreshToken: false
+        }
+    });
+
+    await ensureBucket(supabase, newsBucket);
+    await ensureBucket(supabase, peopleBucket);
+
+    const newsResult = await importNews(supabase);
+    const peopleResult = await importPeople(supabase);
+
+    console.log('Supabase import complete.');
+    console.log(JSON.stringify({ ...newsResult, ...peopleResult }, null, 2));
+}
+
+main().catch((error) => {
+    console.error('Supabase import failed.');
+    console.error(error.message || error);
+    process.exitCode = 1;
+});

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
     <div id="app">
         <NavBar v-if="showSiteChrome"></NavBar>
-        <div class="espacamento-header">
+        <div :class="{ 'espacamento-header': showSiteChrome }">
             <RouterView />
         </div>
         <Footer v-if="showSiteChrome"></Footer>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,11 @@
 <template>
     <div id="app">
-        <NavBar></NavBar>
+        <NavBar v-if="showSiteChrome"></NavBar>
         <div class="espacamento-header">
             <RouterView />
         </div>
-        <Footer></Footer>
-        <MobileMenu class="overlay-menu"></MobileMenu>
+        <Footer v-if="showSiteChrome"></Footer>
+        <MobileMenu v-if="showSiteChrome" class="overlay-menu"></MobileMenu>
     </div>
 </template>
 
@@ -21,6 +21,11 @@ export default {
         RouterView,
         MobileMenu,
         Footer,
+    },
+    computed: {
+        showSiteChrome() {
+            return !this.$route.meta?.hideSiteChrome;
+        }
     },
     methods: {},
     onBeforeRouteUpdate() {

--- a/src/api/resource/articles.js
+++ b/src/api/resource/articles.js
@@ -3,6 +3,7 @@ import MembersResource from '../resource/people.js';
 
 const LOCAL_BIB_ROUTE = 'papers.bib';
 const DBLP_BIB_URL = 'https://dblp.org/pid';
+const OPEN_ALEX_WORKS_URL = 'https://api.openalex.org/works';
 const CACHE_PREFIX = 'dblp-bib-cache:';
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
@@ -63,8 +64,39 @@ async function fetchBibText(bibRoute) {
     return response.text();
 }
 
+async function fetchJson(url) {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+        throw new Error(`Failed to fetch JSON from ${url}`);
+    }
+
+    return response.json();
+}
+
 function parseBibText(bibText) {
     return Cite.input(bibText);
+}
+
+function slugify(value) {
+    return `${value || ''}`
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+function getArticleIdentifier(article) {
+    const articleTitle = slugify(article?.title || 'publication');
+    const articleYear = getArticleYear(article) || 'unknown';
+    const firstAuthor = article?.author?.[0]
+        ? slugify(`${article.author[0].given || ''} ${article.author[0].family || ''}`)
+        : 'author';
+
+    return article?.DOI || article?.doi || `${articleTitle}-${articleYear}-${firstAuthor}`;
+}
+
+function getArticleId(article) {
+    return slugify(getArticleIdentifier(article));
 }
 
 function getArticleYear(article) {
@@ -91,11 +123,23 @@ function normalizeAuthors(article) {
 }
 
 function normalizeArticle(article) {
+    const normalizedAuthors = normalizeAuthors(article);
+    const normalizedDoi = article.DOI || article.doi || '';
+
     return {
         ...article,
-        DOI: article.DOI || article.doi || '',
+        id: getArticleId({
+            ...article,
+            DOI: normalizedDoi,
+            author: normalizedAuthors
+        }),
+        DOI: normalizedDoi,
         URL: article.URL || article.url || '',
-        author: normalizeAuthors(article),
+        abstract: article.abstract || '',
+        pdfUrl: article.pdfUrl || '',
+        landingPageUrl: article.landingPageUrl || article.URL || article.url || '',
+        openAlexId: article.openAlexId || '',
+        author: normalizedAuthors,
         'container-title': normalizeContainerTitle(article)
     };
 }
@@ -156,6 +200,53 @@ async function getDblpArticlesByPid(pid) {
     const bibText = await fetchBibText(`${DBLP_BIB_URL}/${pid}.bib`);
     writeCache(pid, bibText);
     return normalizeArticles(parseBibText(bibText));
+}
+
+function reconstructAbstract(abstractInvertedIndex) {
+    if (!abstractInvertedIndex || typeof abstractInvertedIndex !== 'object') {
+        return '';
+    }
+
+    const orderedWords = [];
+
+    Object.entries(abstractInvertedIndex).forEach(([word, positions]) => {
+        positions.forEach((position) => {
+            orderedWords[position] = word;
+        });
+    });
+
+    return orderedWords.filter(Boolean).join(' ');
+}
+
+function normalizeOpenAlexWork(work) {
+    const doi = work?.doi ? work.doi.replace(/^https?:\/\/doi\.org\//i, '') : '';
+
+    return {
+        abstract: reconstructAbstract(work?.abstract_inverted_index),
+        pdfUrl: work?.primary_location?.pdf_url || work?.best_oa_location?.pdf_url || work?.open_access?.oa_url || '',
+        landingPageUrl: work?.primary_location?.landing_page_url || work?.best_oa_location?.landing_page_url || work?.doi || '',
+        openAlexId: work?.id || '',
+        citationCount: work?.cited_by_count || 0,
+        publicationDate: work?.publication_date || '',
+        DOI: doi
+    };
+}
+
+async function getOpenAlexWorkByDoi(doi) {
+    if (!doi) {
+        return null;
+    }
+
+    const normalizedDoi = doi.replace(/^https?:\/\/doi\.org\//i, '');
+    const filterValue = encodeURIComponent(`doi:https://doi.org/${normalizedDoi}`);
+    const response = await fetchJson(`${OPEN_ALEX_WORKS_URL}?filter=${filterValue}`);
+    const work = response?.results?.[0];
+
+    if (!work) {
+        return null;
+    }
+
+    return normalizeOpenAlexWork(work);
 }
 
 const ArticlesResource = {
@@ -224,6 +315,42 @@ const ArticlesResource = {
         }));
 
         return articlesWithAuthors;
+    },
+
+    async getArticleById(articleId, collection = null) {
+        const articles = collection || await this.getAllArticles();
+        return articles.find((article) => article.id === articleId) || null;
+    },
+
+    async getArticleDetailsById(articleId, collection = null) {
+        const article = await this.getArticleById(articleId, collection);
+
+        if (!article) {
+            return null;
+        }
+
+        if (!article.DOI) {
+            return {
+                ...article,
+                hasRemoteDetails: false
+            };
+        }
+
+        try {
+            const remoteDetails = await getOpenAlexWorkByDoi(article.DOI);
+
+            return normalizeArticle({
+                ...article,
+                ...remoteDetails
+            });
+        } catch (error) {
+            console.warn(`Unable to fetch OpenAlex details for DOI ${article.DOI}.`, error);
+
+            return {
+                ...article,
+                hasRemoteDetails: false
+            };
+        }
     }
 };
 

--- a/src/api/resource/articles.js
+++ b/src/api/resource/articles.js
@@ -7,10 +7,13 @@ const OPEN_ALEX_WORKS_URL = 'https://api.openalex.org/works';
 const CACHE_PREFIX = 'dblp-bib-cache:';
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
+// Attach 'dblp-bib-cache' to the beginning of an author's DBLP PID
 function getCacheKey(pid) {
     return `${CACHE_PREFIX}${pid}`;
 }
 
+// Reads BibTeX text from localStorage cache. If entries are older than
+// 24 hours or missing, clear the cache
 function readCache(pid) {
     if (typeof window === 'undefined' || !window.localStorage) {
         return null;
@@ -41,6 +44,7 @@ function readCache(pid) {
     }
 }
 
+// Store BibTeX text in localStorage with timestamp accessed
 function writeCache(pid, data) {
     if (typeof window === 'undefined' || !window.localStorage) {
         return;
@@ -54,6 +58,7 @@ function writeCache(pid, data) {
     window.localStorage.setItem(getCacheKey(pid), value);
 }
 
+// Request a BibTeX resource and return the response as text
 async function fetchBibText(bibRoute) {
     const response = await fetch(bibRoute);
 
@@ -64,6 +69,7 @@ async function fetchBibText(bibRoute) {
     return response.text();
 }
 
+// Request a JSON resource and return the parsed response
 async function fetchJson(url) {
     const response = await fetch(url);
 
@@ -74,10 +80,12 @@ async function fetchJson(url) {
     return response.json();
 }
 
+// Cite BibTeX text
 function parseBibText(bibText) {
     return Cite.input(bibText);
 }
 
+// Create a URL-safe ID from a value
 function slugify(value) {
     return `${value || ''}`
         .toLowerCase()
@@ -85,6 +93,8 @@ function slugify(value) {
         .replace(/^-+|-+$/g, '');
 }
 
+// Create a stable identifier for a paper using DOI if available,
+// otherwise title, year, and first author
 function getArticleIdentifier(article) {
     const articleTitle = slugify(article?.title || 'publication');
     const articleYear = getArticleYear(article) || 'unknown';
@@ -99,10 +109,12 @@ function getArticleId(article) {
     return slugify(getArticleIdentifier(article));
 }
 
+// Get article's publication year, or return 0
 function getArticleYear(article) {
     return article?.issued?.['date-parts']?.[0]?.[0] || 0;
 }
 
+// Make sure venue name is a usable string by joining the array
 function normalizeContainerTitle(article) {
     if (Array.isArray(article['container-title'])) {
         return article['container-title'].join(', ');
@@ -111,6 +123,7 @@ function normalizeContainerTitle(article) {
     return article['container-title'] || article.publisher || 'Publication';
 }
 
+// Split an array of authors into "given" and "family" or "literal" values
 function normalizeAuthors(article) {
     if (!Array.isArray(article.author)) {
         return [];
@@ -122,9 +135,11 @@ function normalizeAuthors(article) {
     }));
 }
 
+// Composite function organizing article fields into a consistent shape
 function normalizeArticle(article) {
     const normalizedAuthors = normalizeAuthors(article);
     const normalizedDoi = article.DOI || article.doi || '';
+    const normalizedUrl = article.URL || article.url || '';
 
     return {
         ...article,
@@ -134,22 +149,24 @@ function normalizeArticle(article) {
             author: normalizedAuthors
         }),
         DOI: normalizedDoi,
-        URL: article.URL || article.url || '',
+        URL: normalizedUrl,
         abstract: article.abstract || '',
         pdfUrl: article.pdfUrl || '',
-        landingPageUrl: article.landingPageUrl || article.URL || article.url || '',
+        landingPageUrl: article.landingPageUrl || normalizedUrl,
         openAlexId: article.openAlexId || '',
         author: normalizedAuthors,
         'container-title': normalizeContainerTitle(article)
     };
 }
 
+// Sort articles descending by year
 function normalizeArticles(articles) {
     return articles
         .map(normalizeArticle)
         .sort((firstArticle, secondArticle) => getArticleYear(secondArticle) - getArticleYear(firstArticle));
 }
 
+// Check if any author in a paper matches a member's author_name
 function matchesAnyAuthorName(article, names) {
     if (!Array.isArray(article.author) || !Array.isArray(names) || names.length === 0) {
         return false;
@@ -163,6 +180,7 @@ function matchesAnyAuthorName(article, names) {
     });
 }
 
+// Remove duplicate articles based on DOI, then title, year, and authors
 function dedupeArticles(articles) {
     const seenArticles = new Set();
 
@@ -181,11 +199,14 @@ function dedupeArticles(articles) {
     });
 }
 
+// Fetch papers.bib and format the text (backup)
 async function getLocalArticles() {
     const bibText = await fetchBibText(LOCAL_BIB_ROUTE);
     return normalizeArticles(parseBibText(bibText));
 }
 
+// First try localStorage, then fetch the DBLP API, cache the BibTeX,
+// format it, and return the author's articles
 async function getDblpArticlesByPid(pid) {
     if (!pid) {
         return [];
@@ -202,6 +223,7 @@ async function getDblpArticlesByPid(pid) {
     return normalizeArticles(parseBibText(bibText));
 }
 
+// Reconstruct an abstract from OpenAlex's inverted index
 function reconstructAbstract(abstractInvertedIndex) {
     if (!abstractInvertedIndex || typeof abstractInvertedIndex !== 'object') {
         return '';
@@ -218,13 +240,34 @@ function reconstructAbstract(abstractInvertedIndex) {
     return orderedWords.filter(Boolean).join(' ');
 }
 
+function getOpenAlexPdfUrl(work) {
+    const locationWithPdf = [
+        work?.primary_location,
+        work?.best_oa_location,
+        ...(Array.isArray(work?.locations) ? work.locations : [])
+    ].find((location) => location?.pdf_url);
+
+    return locationWithPdf?.pdf_url || '';
+}
+
+function getOpenAlexLandingPageUrl(work) {
+    return (
+        work?.primary_location?.landing_page_url ||
+        work?.best_oa_location?.landing_page_url ||
+        work?.open_access?.oa_url ||
+        work?.doi ||
+        ''
+    );
+}
+
+// Normalize the OpenAlex work response into the same article shape
 function normalizeOpenAlexWork(work) {
     const doi = work?.doi ? work.doi.replace(/^https?:\/\/doi\.org\//i, '') : '';
 
     return {
         abstract: reconstructAbstract(work?.abstract_inverted_index),
-        pdfUrl: work?.primary_location?.pdf_url || work?.best_oa_location?.pdf_url || work?.open_access?.oa_url || '',
-        landingPageUrl: work?.primary_location?.landing_page_url || work?.best_oa_location?.landing_page_url || work?.doi || '',
+        pdfUrl: getOpenAlexPdfUrl(work),
+        landingPageUrl: getOpenAlexLandingPageUrl(work),
         openAlexId: work?.id || '',
         citationCount: work?.cited_by_count || 0,
         publicationDate: work?.publication_date || '',
@@ -232,6 +275,7 @@ function normalizeOpenAlexWork(work) {
     };
 }
 
+// Fetch a single OpenAlex work by DOI
 async function getOpenAlexWorkByDoi(doi) {
     if (!doi) {
         return null;
@@ -250,6 +294,7 @@ async function getOpenAlexWorkByDoi(doi) {
 }
 
 const ArticlesResource = {
+    // Uses local papers.bib and filters by author aliases (backup)
     async getArticlesByAuthor(names) {
         const localArticles = await getLocalArticles();
         return localArticles.filter((article) => matchesAnyAuthorName(article, names));

--- a/src/api/resource/news.js
+++ b/src/api/resource/news.js
@@ -1,6 +1,47 @@
 import localData from '/public/posts.json';
 import { isSupabaseConfigured, supabase } from '../../lib/supabase';
 
+const NEWS_IMAGES_BUCKET = 'news-images';
+const NEWS_STORAGE_PREFIX = `${NEWS_IMAGES_BUCKET}/`;
+
+function normalizeStoredNewsImagePath(imagePath) {
+    if (!imagePath) {
+        return '';
+    }
+
+    const normalizedValue = `${imagePath}`.trim();
+    const normalizedPath = normalizedValue.replace(/^\/+/, '');
+
+    if (normalizedPath.startsWith(NEWS_STORAGE_PREFIX)) {
+        return normalizedPath;
+    }
+
+    try {
+        const parsedUrl = new URL(normalizedValue, 'http://localhost');
+        const marker = `/storage/v1/object/public/${NEWS_IMAGES_BUCKET}/`;
+        const storagePathIndex = parsedUrl.pathname.indexOf(marker);
+
+        if (storagePathIndex >= 0) {
+            const filePath = decodeURIComponent(parsedUrl.pathname.slice(storagePathIndex + marker.length));
+            return `${NEWS_STORAGE_PREFIX}${filePath}`;
+        }
+    } catch {
+        // Keep the original value when it is not a valid URL.
+    }
+
+    return normalizedPath;
+}
+
+function getNewsStorageFilePath(imagePath) {
+    const normalizedPath = normalizeStoredNewsImagePath(imagePath);
+
+    if (!normalizedPath.startsWith(NEWS_STORAGE_PREFIX)) {
+        return '';
+    }
+
+    return normalizedPath.slice(NEWS_STORAGE_PREFIX.length);
+}
+
 function normalizeNewsItem(news) {
     return {
         id: news.id,
@@ -8,14 +49,85 @@ function normalizeNewsItem(news) {
         date: news.date,
         person: news.person || [],
         tag: news.tag || '',
-        image: news.image || '',
+        image: normalizeStoredNewsImagePath(news.image),
         description: news.description || '',
-        published: news.published !== false
+        published: news.published !== false,
+        sort_order: typeof news.sort_order === 'number' ? news.sort_order : null
     };
 }
 
 function getLocalNews() {
     return localData.posts.map(normalizeNewsItem);
+}
+
+function sanitizePathSegment(value) {
+    return `${value || ''}`
+        .toLowerCase()
+        .replace(/[^a-z0-9-_]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 80) || 'news-item';
+}
+
+function sanitizeFileName(name) {
+    const lastDotIndex = name.lastIndexOf('.');
+    const baseName = lastDotIndex >= 0 ? name.slice(0, lastDotIndex) : name;
+    const extension = lastDotIndex >= 0 ? name.slice(lastDotIndex).toLowerCase() : '';
+
+    return `${sanitizePathSegment(baseName)}${extension}`;
+}
+
+export function resolveNewsImageUrl(imagePath) {
+    if (!imagePath) {
+        return '';
+    }
+
+    if (imagePath.startsWith('data:') || imagePath.startsWith('blob:')) {
+        return imagePath;
+    }
+
+    const storageFilePath = getNewsStorageFilePath(imagePath);
+
+    if (storageFilePath && isSupabaseConfigured && supabase) {
+        const {
+            data: { publicUrl }
+        } = supabase.storage.from(NEWS_IMAGES_BUCKET).getPublicUrl(storageFilePath);
+
+        return publicUrl;
+    }
+
+    if (/^(https?:)?\/\//i.test(imagePath)) {
+        return imagePath;
+    }
+
+    const normalizedPath = imagePath.replace(/^\/+/, '');
+    return `${import.meta.env.BASE_URL || '/'}${normalizedPath}`;
+}
+
+function sortNewsItems(items) {
+    return items.sort((firstItem, secondItem) => {
+        const firstSortOrder = typeof firstItem.sort_order === 'number' ? firstItem.sort_order : Number.MAX_SAFE_INTEGER;
+        const secondSortOrder = typeof secondItem.sort_order === 'number' ? secondItem.sort_order : Number.MAX_SAFE_INTEGER;
+
+        if (firstSortOrder !== secondSortOrder) {
+            return firstSortOrder - secondSortOrder;
+        }
+
+        return `${secondItem.date || ''}`.localeCompare(`${firstItem.date || ''}`);
+    });
+}
+
+function mergeNewsItems(localItems, remoteItems) {
+    const mergedItems = new Map();
+
+    localItems.forEach((item) => {
+        mergedItems.set(item.id, item);
+    });
+
+    remoteItems.forEach((item) => {
+        mergedItems.set(item.id, item);
+    });
+
+    return sortNewsItems(Array.from(mergedItems.values()));
 }
 
 async function getRemoteNews(includeDrafts = false) {
@@ -40,15 +152,18 @@ async function getRemoteNews(includeDrafts = false) {
 
 const NewsResource = {
     async getNews() {
+        const localNews = getLocalNews();
+
         if (!isSupabaseConfigured || !supabase) {
-            return getLocalNews();
+            return sortNewsItems(localNews);
         }
 
         try {
-            return await getRemoteNews(false);
+            const remoteNews = await getRemoteNews(false);
+            return mergeNewsItems(localNews, remoteNews);
         } catch (error) {
             console.warn('Falling back to local news data.', error);
-            return getLocalNews();
+            return sortNewsItems(localNews);
         }
     },
 
@@ -76,7 +191,7 @@ const NewsResource = {
             date: newsItem.date,
             person: newsItem.person || [],
             tag: newsItem.tag || '',
-            image: newsItem.image || '',
+            image: normalizeStoredNewsImagePath(newsItem.image),
             description: newsItem.description || '',
             published: newsItem.published !== false
         };
@@ -92,6 +207,41 @@ const NewsResource = {
         }
 
         return normalizeNewsItem(data);
+    },
+
+    async uploadNewsImage(file, newsId) {
+        if (!isSupabaseConfigured || !supabase) {
+            throw new Error('Supabase is not configured.');
+        }
+
+        if (!file) {
+            throw new Error('Choose an image before uploading.');
+        }
+
+        const safeNewsId = sanitizePathSegment(newsId);
+        const safeFileName = sanitizeFileName(file.name || 'upload-image');
+        const filePath = `${safeNewsId}/${Date.now()}-${safeFileName}`;
+
+        const { error } = await supabase.storage
+            .from(NEWS_IMAGES_BUCKET)
+            .upload(filePath, file, {
+                cacheControl: '3600',
+                upsert: false,
+                contentType: file.type || undefined
+            });
+
+        if (error) {
+            throw error;
+        }
+
+        const {
+            data: { publicUrl }
+        } = supabase.storage.from(NEWS_IMAGES_BUCKET).getPublicUrl(filePath);
+
+        return {
+            filePath: `${NEWS_STORAGE_PREFIX}${filePath}`,
+            publicUrl
+        };
     },
 
     async deleteNewsItem(id) {

--- a/src/api/resource/news.js
+++ b/src/api/resource/news.js
@@ -1,33 +1,113 @@
-import data from '/public/posts.json';
+import localData from '/public/posts.json';
+import { isSupabaseConfigured, supabase } from '../../lib/supabase';
+
+function normalizeNewsItem(news) {
+    return {
+        id: news.id,
+        title: news.title,
+        date: news.date,
+        person: news.person || [],
+        tag: news.tag || '',
+        image: news.image || '',
+        description: news.description || '',
+        published: news.published !== false
+    };
+}
+
+function getLocalNews() {
+    return localData.posts.map(normalizeNewsItem);
+}
+
+async function getRemoteNews(includeDrafts = false) {
+    const query = supabase
+        .from('news_posts')
+        .select('id, title, date, person, tag, image, description, published, sort_order')
+        .order('sort_order', { ascending: true, nullsFirst: false })
+        .order('date', { ascending: false });
+
+    if (!includeDrafts) {
+        query.eq('published', true);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+        throw error;
+    }
+
+    return (data || []).map(normalizeNewsItem);
+}
 
 const NewsResource = {
-    getNews() {
-        const news = data.posts.map(news => ({
-            id: news.id,
-            title: news.title,
-            date: news.date,
-            person: news.person,
-            tag: news.tag,
-            image: news.image,
-            description: news.description
-        }));
+    async getNews() {
+        if (!isSupabaseConfigured || !supabase) {
+            return getLocalNews();
+        }
 
-        return Promise.resolve(news);
+        try {
+            return await getRemoteNews(false);
+        } catch (error) {
+            console.warn('Falling back to local news data.', error);
+            return getLocalNews();
+        }
     },
 
-    getNewsById(id) {
-        const news = data.posts.find(news => news.id === id);
-        const newsData = news ? {
-            title: news.title,
-            date: news.date,
-            person: news.person,
-            tag: news.tag,
-            image: news.image,
-            description: news.description
-        } : null;
+    async getNewsById(id) {
+        const news = await this.getNews();
+        return news.find((item) => item.id === id) || null;
+    },
 
-        return Promise.resolve(newsData);
+    async getAdminNews() {
+        if (!isSupabaseConfigured || !supabase) {
+            return getLocalNews();
+        }
+
+        return getRemoteNews(true);
+    },
+
+    async upsertNewsItem(newsItem) {
+        if (!isSupabaseConfigured || !supabase) {
+            throw new Error('Supabase is not configured.');
+        }
+
+        const payload = {
+            id: newsItem.id,
+            title: newsItem.title,
+            date: newsItem.date,
+            person: newsItem.person || [],
+            tag: newsItem.tag || '',
+            image: newsItem.image || '',
+            description: newsItem.description || '',
+            published: newsItem.published !== false
+        };
+
+        const { data, error } = await supabase
+            .from('news_posts')
+            .upsert(payload)
+            .select()
+            .single();
+
+        if (error) {
+            throw error;
+        }
+
+        return normalizeNewsItem(data);
+    },
+
+    async deleteNewsItem(id) {
+        if (!isSupabaseConfigured || !supabase) {
+            throw new Error('Supabase is not configured.');
+        }
+
+        const { error } = await supabase
+            .from('news_posts')
+            .delete()
+            .eq('id', id);
+
+        if (error) {
+            throw error;
+        }
     }
-}
+};
 
 export default NewsResource;

--- a/src/api/resource/news.js
+++ b/src/api/resource/news.js
@@ -130,6 +130,19 @@ function mergeNewsItems(localItems, remoteItems) {
     return sortNewsItems(Array.from(mergedItems.values()));
 }
 
+function buildNewsPayload(newsItem) {
+    return {
+        id: newsItem.id,
+        title: newsItem.title,
+        date: newsItem.date,
+        person: newsItem.person || [],
+        tag: newsItem.tag || '',
+        image: normalizeStoredNewsImagePath(newsItem.image),
+        description: newsItem.description || '',
+        published: newsItem.published !== false
+    };
+}
+
 async function getRemoteNews(includeDrafts = false) {
     const query = supabase
         .from('news_posts')
@@ -185,20 +198,32 @@ const NewsResource = {
             throw new Error('Supabase is not configured.');
         }
 
-        const payload = {
-            id: newsItem.id,
-            title: newsItem.title,
-            date: newsItem.date,
-            person: newsItem.person || [],
-            tag: newsItem.tag || '',
-            image: normalizeStoredNewsImagePath(newsItem.image),
-            description: newsItem.description || '',
-            published: newsItem.published !== false
-        };
+        const payload = buildNewsPayload(newsItem);
 
         const { data, error } = await supabase
             .from('news_posts')
             .upsert(payload)
+            .select()
+            .single();
+
+        if (error) {
+            throw error;
+        }
+
+        return normalizeNewsItem(data);
+    },
+
+    async updateNewsItem(originalId, newsItem) {
+        if (!isSupabaseConfigured || !supabase) {
+            throw new Error('Supabase is not configured.');
+        }
+
+        const payload = buildNewsPayload(newsItem);
+
+        const { data, error } = await supabase
+            .from('news_posts')
+            .update(payload)
+            .eq('id', originalId)
             .select()
             .single();
 

--- a/src/api/resource/people.js
+++ b/src/api/resource/people.js
@@ -136,6 +136,24 @@ function getLocalMembers() {
     return sortMembers(localData.members.map(normalizeMember));
 }
 
+function buildMemberPayload(member) {
+    return {
+        slug: member.slug || `${member.firstName} ${member.lastName}`.trim().replace(/ /g, '-'),
+        first_name: member.firstName,
+        last_name: member.lastName,
+        role: member.role,
+        description: member.description || '',
+        photos: normalizePhotos(member.photos || {}),
+        contacts: member.contacts || {},
+        research_keywords: member.research_keywords || [],
+        highlighted_publications: member.highlighted_publications || [],
+        author_name: member.author_name || [],
+        dblp_pid: member.dblpPid || '',
+        projects: member.projects || [],
+        is_active: member.is_active !== false
+    };
+}
+
 async function getRemoteMembers() {
     const { data, error } = await supabase
         .from('people_profiles')
@@ -248,25 +266,32 @@ const MembersResource = {
             throw new Error('Supabase is not configured.');
         }
 
-        const payload = {
-            slug: member.slug || `${member.firstName} ${member.lastName}`.trim().replace(/ /g, '-'),
-            first_name: member.firstName,
-            last_name: member.lastName,
-            role: member.role,
-            description: member.description || '',
-            photos: normalizePhotos(member.photos || {}),
-            contacts: member.contacts || {},
-            research_keywords: member.research_keywords || [],
-            highlighted_publications: member.highlighted_publications || [],
-            author_name: member.author_name || [],
-            dblp_pid: member.dblpPid || '',
-            projects: member.projects || [],
-            is_active: member.is_active !== false
-        };
+        const payload = buildMemberPayload(member);
 
         const { data, error } = await supabase
             .from('people_profiles')
             .upsert(payload)
+            .select()
+            .single();
+
+        if (error) {
+            throw error;
+        }
+
+        return normalizeRemoteMember(data);
+    },
+
+    async updateMember(originalSlug, member) {
+        if (!isSupabaseConfigured || !supabase) {
+            throw new Error('Supabase is not configured.');
+        }
+
+        const payload = buildMemberPayload(member);
+
+        const { data, error } = await supabase
+            .from('people_profiles')
+            .update(payload)
+            .eq('slug', originalSlug)
             .select()
             .single();
 

--- a/src/api/resource/people.js
+++ b/src/api/resource/people.js
@@ -1,112 +1,210 @@
-import data from '/public/members.json';
+import localData from '/public/members.json';
+import { isSupabaseConfigured, supabase } from '../../lib/supabase';
 
-const MembersResource = { 
-    getMembers() {
-        const members = data.members.map(member => ({
-            firstName: member.first_name,
-            lastName: member.last_name,
-            role: member.role,
-            photos: member.photos,
-            contacts: member.contacts,
-            author_name: member.author_name,
-            dblpPid: member.dblp_pid || ''
-        }));
+function slugFromMember(member) {
+    return `${member.first_name?.trim() || ''} ${member.last_name?.trim() || ''}`.trim().replace(/ /g, '-');
+}
 
-        members.sort((a, b) => {
-            const nameA = a.firstName + ' ' + a.lastName;
-            const nameB = b.firstName + ' ' + b.lastName;
-            if (nameA < nameB) return -1;
-            if (nameA > nameB) return 1;
-            return 0;
-        });
+function normalizeMember(member) {
+    return {
+        firstName: member.first_name,
+        lastName: member.last_name,
+        role: member.role,
+        photos: member.photos || {
+            photo_with_background: 'images/people/user_icon.png',
+            photo_without_background: 'images/people/user_icon.png'
+        },
+        contacts: member.contacts || {},
+        description: member.description || '',
+        research_keywords: member.research_keywords || [],
+        highlighted_publications: member.highlighted_publications || [],
+        author_name: member.author_name || [],
+        dblpPid: member.dblp_pid || '',
+        projects: member.projects || [],
+        slug: member.slug || slugFromMember(member)
+    };
+}
 
-        return Promise.resolve(members);
-    },
+function normalizeRemoteMember(member) {
+    return normalizeMember({
+        ...member,
+        photos: member.photos || member.photos_json,
+        contacts: member.contacts || member.contacts_json,
+        research_keywords: member.research_keywords || [],
+        author_name: member.author_name || [],
+        projects: member.projects || []
+    });
+}
 
-    getMembersByRole(role) {
-        let members;
-        if (role === 'Student') {
-            members = data.members
-                .filter(member => !member.role.includes('Professor'));
-        } else {
-            members = data.members
-                .filter(member => member.role.includes(role));
+function sortMembers(members) {
+    return members.sort((a, b) => {
+        const nameA = `${a.firstName} ${a.lastName}`;
+        const nameB = `${b.firstName} ${b.lastName}`;
+        return nameA.localeCompare(nameB);
+    });
+}
+
+function getLocalMembers() {
+    return sortMembers(localData.members.map(normalizeMember));
+}
+
+async function getRemoteMembers() {
+    const { data, error } = await supabase
+        .from('people_profiles')
+        .select(`
+            id,
+            slug,
+            first_name,
+            last_name,
+            role,
+            description,
+            photos,
+            contacts,
+            research_keywords,
+            highlighted_publications,
+            author_name,
+            dblp_pid,
+            projects,
+            is_active
+        `)
+        .eq('is_active', true);
+
+    if (error) {
+        throw error;
+    }
+
+    return sortMembers((data || []).map(normalizeRemoteMember));
+}
+
+const MembersResource = {
+    async getMembers() {
+        if (!isSupabaseConfigured || !supabase) {
+            return getLocalMembers();
         }
 
-        members = members.map(member => ({
-            firstName: member.first_name,
-            lastName: member.last_name,
-            role: member.role,
-            photos: member.photos,
-            contacts: member.contacts,
-            author_name: member.author_name,
-            dblpPid: member.dblp_pid || ''
-        }));
-
-        members.sort((a, b) => {
-            const nameA = a.firstName + ' ' + a.lastName;
-            const nameB = b.firstName + ' ' + b.lastName;
-            if (nameA < nameB) return -1;
-            if (nameA > nameB) return 1;
-            return 0;
-        });
-
-        return Promise.resolve(members);
+        try {
+            return await getRemoteMembers();
+        } catch (error) {
+            console.warn('Falling back to local member data.', error);
+            return getLocalMembers();
+        }
     },
 
-    getMembersByEmail(email) {
-        const member = data.members.find(member => member.contacts.email === email);
-        const memberData = member ? {
-            firstName: member.first_name,
-            lastName: member.last_name,
-            role: member.role,
-            photos: member.photos,
-            contacts: member.contacts,
-            description: member.description,
-            research_keywords: member.research_keywords,
-            highlighted_publications: member.highlighted_publications,
-            dblpPid: member.dblp_pid || ''
-        } : null;
-        
-        return Promise.resolve(memberData);
+    async getMembersByRole(role) {
+        const members = await this.getMembers();
+
+        if (role === 'Student') {
+            return members.filter((member) => !member.role.includes('Professor'));
+        }
+
+        return members.filter((member) => member.role.includes(role));
     },
 
-    getFirstMemberByName(full_name) {
-        const member = data.members.find(member => {
-            const memberName = `${member.first_name.trim()} ${member.last_name.trim()}`.replace(/ /g, '-');
-            return memberName === full_name;
-        });
-
-        const memberData = member ? {
-            firstName: member.first_name,
-            lastName: member.last_name,
-            role: member.role,
-            photos: member.photos,
-            contacts: member.contacts,
-            description: member.description,
-            research_keywords: member.research_keywords,
-            highlighted_publications: member.highlighted_publications,
-            author_name: member.author_name,
-            dblpPid: member.dblp_pid || ''
-        } : null;
-
-        return Promise.resolve(memberData);
+    async getMembersByEmail(email) {
+        const members = await this.getMembers();
+        return members.find((member) => member.contacts?.email === email) || null;
     },
 
-    getMemberByAuthorName(authorNames) {
-        const members = data.members
-            .filter(member => {
-                return member.author_name ? member.author_name.some(name => authorNames.includes(name)) : false;
+    async getFirstMemberByName(fullName) {
+        const members = await this.getMembers();
+        return members.find((member) => member.slug === fullName) || null;
+    },
+
+    async getMemberByAuthorName(authorNames) {
+        const members = await this.getMembers();
+
+        return members
+            .filter((member) => {
+                return member.author_name ? member.author_name.some((name) => authorNames.includes(name)) : false;
             })
-            .map(member => ({
-                first_name: member.first_name,
-                last_name: member.last_name,
+            .map((member) => ({
+                first_name: member.firstName,
+                last_name: member.lastName,
                 contacts: member.contacts,
                 photos: member.photos
             }));
+    },
 
-        return Promise.resolve(members);
+    async getAdminMembers() {
+        if (!isSupabaseConfigured || !supabase) {
+            return getLocalMembers();
+        }
+
+        const { data, error } = await supabase
+            .from('people_profiles')
+            .select(`
+                id,
+                slug,
+                first_name,
+                last_name,
+                role,
+                description,
+                photos,
+                contacts,
+                research_keywords,
+                highlighted_publications,
+                author_name,
+                dblp_pid,
+                projects,
+                is_active
+            `)
+            .order('first_name');
+
+        if (error) {
+            throw error;
+        }
+
+        return (data || []).map(normalizeRemoteMember);
+    },
+
+    async upsertMember(member) {
+        if (!isSupabaseConfigured || !supabase) {
+            throw new Error('Supabase is not configured.');
+        }
+
+        const payload = {
+            slug: member.slug || `${member.firstName} ${member.lastName}`.trim().replace(/ /g, '-'),
+            first_name: member.firstName,
+            last_name: member.lastName,
+            role: member.role,
+            description: member.description || '',
+            photos: member.photos || {},
+            contacts: member.contacts || {},
+            research_keywords: member.research_keywords || [],
+            highlighted_publications: member.highlighted_publications || [],
+            author_name: member.author_name || [],
+            dblp_pid: member.dblpPid || '',
+            projects: member.projects || [],
+            is_active: member.is_active !== false
+        };
+
+        const { data, error } = await supabase
+            .from('people_profiles')
+            .upsert(payload)
+            .select()
+            .single();
+
+        if (error) {
+            throw error;
+        }
+
+        return normalizeRemoteMember(data);
+    },
+
+    async deleteMember(slug) {
+        if (!isSupabaseConfigured || !supabase) {
+            throw new Error('Supabase is not configured.');
+        }
+
+        const { error } = await supabase
+            .from('people_profiles')
+            .delete()
+            .eq('slug', slug);
+
+        if (error) {
+            throw error;
+        }
     }
-}
+};
 
 export default MembersResource;

--- a/src/api/resource/people.js
+++ b/src/api/resource/people.js
@@ -1,8 +1,99 @@
 import localData from '/public/members.json';
 import { isSupabaseConfigured, supabase } from '../../lib/supabase';
 
+const PEOPLE_IMAGES_BUCKET = 'people-images';
+const PEOPLE_STORAGE_PREFIX = `${PEOPLE_IMAGES_BUCKET}/`;
+
 function slugFromMember(member) {
     return `${member.first_name?.trim() || ''} ${member.last_name?.trim() || ''}`.trim().replace(/ /g, '-');
+}
+
+function sanitizePathSegment(value) {
+    return `${value || ''}`
+        .toLowerCase()
+        .replace(/[^a-z0-9-_]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 80) || 'person';
+}
+
+function sanitizeFileName(name) {
+    const lastDotIndex = name.lastIndexOf('.');
+    const baseName = lastDotIndex >= 0 ? name.slice(0, lastDotIndex) : name;
+    const extension = lastDotIndex >= 0 ? name.slice(lastDotIndex).toLowerCase() : '';
+
+    return `${sanitizePathSegment(baseName)}${extension}`;
+}
+
+function normalizeStoredPeopleImagePath(imagePath) {
+    if (!imagePath) {
+        return '';
+    }
+
+    const normalizedValue = `${imagePath}`.trim();
+    const normalizedPath = normalizedValue.replace(/^\/+/, '');
+
+    if (normalizedPath.startsWith(PEOPLE_STORAGE_PREFIX)) {
+        return normalizedPath;
+    }
+
+    try {
+        const parsedUrl = new URL(normalizedValue, 'http://localhost');
+        const marker = `/storage/v1/object/public/${PEOPLE_IMAGES_BUCKET}/`;
+        const storagePathIndex = parsedUrl.pathname.indexOf(marker);
+
+        if (storagePathIndex >= 0) {
+            const filePath = decodeURIComponent(parsedUrl.pathname.slice(storagePathIndex + marker.length));
+            return `${PEOPLE_STORAGE_PREFIX}${filePath}`;
+        }
+    } catch {
+        // Keep the original value when it is not a valid URL.
+    }
+
+    return normalizedPath;
+}
+
+function getPeopleStorageFilePath(imagePath) {
+    const normalizedPath = normalizeStoredPeopleImagePath(imagePath);
+
+    if (!normalizedPath.startsWith(PEOPLE_STORAGE_PREFIX)) {
+        return '';
+    }
+
+    return normalizedPath.slice(PEOPLE_STORAGE_PREFIX.length);
+}
+
+function normalizePhotos(photos = {}) {
+    return {
+        photo_with_background: normalizeStoredPeopleImagePath(photos.photo_with_background) || 'images/people/user_icon.png',
+        photo_without_background: normalizeStoredPeopleImagePath(photos.photo_without_background) || 'images/people/user_icon.png'
+    };
+}
+
+export function resolveMemberImageUrl(imagePath) {
+    if (!imagePath) {
+        return '';
+    }
+
+    if (imagePath.startsWith('data:') || imagePath.startsWith('blob:')) {
+        return imagePath;
+    }
+
+    const storageFilePath = getPeopleStorageFilePath(imagePath);
+
+    if (storageFilePath && isSupabaseConfigured && supabase) {
+        const {
+            data: { publicUrl }
+        } = supabase.storage.from(PEOPLE_IMAGES_BUCKET).getPublicUrl(storageFilePath);
+
+        return publicUrl;
+    }
+
+    if (/^(https?:)?\/\//i.test(imagePath)) {
+        return imagePath;
+    }
+
+    const normalizedPath = imagePath.replace(/^\/+/, '');
+    return `${import.meta.env.BASE_URL || '/'}${normalizedPath}`;
 }
 
 function normalizeMember(member) {
@@ -10,10 +101,7 @@ function normalizeMember(member) {
         firstName: member.first_name,
         lastName: member.last_name,
         role: member.role,
-        photos: member.photos || {
-            photo_with_background: 'images/people/user_icon.png',
-            photo_without_background: 'images/people/user_icon.png'
-        },
+        photos: normalizePhotos(member.photos),
         contacts: member.contacts || {},
         description: member.description || '',
         research_keywords: member.research_keywords || [],
@@ -52,7 +140,6 @@ async function getRemoteMembers() {
     const { data, error } = await supabase
         .from('people_profiles')
         .select(`
-            id,
             slug,
             first_name,
             last_name,
@@ -133,7 +220,6 @@ const MembersResource = {
         const { data, error } = await supabase
             .from('people_profiles')
             .select(`
-                id,
                 slug,
                 first_name,
                 last_name,
@@ -168,7 +254,7 @@ const MembersResource = {
             last_name: member.lastName,
             role: member.role,
             description: member.description || '',
-            photos: member.photos || {},
+            photos: normalizePhotos(member.photos || {}),
             contacts: member.contacts || {},
             research_keywords: member.research_keywords || [],
             highlighted_publications: member.highlighted_publications || [],
@@ -189,6 +275,42 @@ const MembersResource = {
         }
 
         return normalizeRemoteMember(data);
+    },
+
+    async uploadMemberImage(file, memberSlug, photoVariant) {
+        if (!isSupabaseConfigured || !supabase) {
+            throw new Error('Supabase is not configured.');
+        }
+
+        if (!file) {
+            throw new Error('Choose an image before uploading.');
+        }
+
+        const safeMemberSlug = sanitizePathSegment(memberSlug);
+        const safeVariant = sanitizePathSegment(photoVariant);
+        const safeFileName = sanitizeFileName(file.name || 'profile-image');
+        const filePath = `${safeMemberSlug}/${safeVariant}/${Date.now()}-${safeFileName}`;
+
+        const { error } = await supabase.storage
+            .from(PEOPLE_IMAGES_BUCKET)
+            .upload(filePath, file, {
+                cacheControl: '3600',
+                upsert: false,
+                contentType: file.type || undefined
+            });
+
+        if (error) {
+            throw error;
+        }
+
+        const {
+            data: { publicUrl }
+        } = supabase.storage.from(PEOPLE_IMAGES_BUCKET).getPublicUrl(filePath);
+
+        return {
+            filePath: `${PEOPLE_STORAGE_PREFIX}${filePath}`,
+            publicUrl
+        };
     },
 
     async deleteMember(slug) {

--- a/src/components/cards/NewsCard.vue
+++ b/src/components/cards/NewsCard.vue
@@ -2,7 +2,7 @@
     <div class = "card">
         <div class="image-container" v-if="image">
             <p class="tag" :style="{ backgroundColor: secundary_color }"> {{ tag }} </p>
-            <img class="image" :src="image" alt="Profile"/>
+            <img class="image" :src="resolveImageUrl(image)" alt="Profile"/>
         </div>
         
         <p class="tagNoImage" :style="{ backgroundColor: secundary_color }" v-else> {{ tag }} </p>
@@ -21,6 +21,7 @@
 
 <script>
 import research_lab from '/public/research_lab.json'
+import { resolveNewsImageUrl } from '../../api/resource/news';
 
 export default {
     setup() {
@@ -45,6 +46,10 @@ export default {
     },
 
     methods: {
+        resolveImageUrl(image) {
+            return resolveNewsImageUrl(image);
+        },
+
         goToNews() {
             this.$router.push(`/news/${this.id}`);
         }

--- a/src/components/cards/NewsCard.vue
+++ b/src/components/cards/NewsCard.vue
@@ -8,7 +8,7 @@
         <p class="tagNoImage" :style="{ backgroundColor: secundary_color }" v-else> {{ tag }} </p>
         
         <p class = "date"> {{ date }} </p>
-        <p class = "title" > {{ title }} </p>
+        <p class = "title" > {{ truncatedTitle }} </p>
         
         <button class = "read_more" :style="{ backgroundColor: primary_color }" @click = "goToNews"> 
             <div class = "link-container"> <!-- Add this div -->
@@ -24,6 +24,19 @@ import research_lab from '/public/research_lab.json'
 import { resolveNewsImageUrl } from '../../api/resource/news';
 
 export default {
+    computed: {
+        truncatedTitle() {
+            const maxLength = 50;
+            const normalizedTitle = `${this.title || ''}`.trim();
+
+            if (normalizedTitle.length <= maxLength) {
+                return normalizedTitle;
+            }
+
+            return `${normalizedTitle.slice(0, maxLength).trimEnd()}...`;
+        }
+    },
+
     setup() {
         return
     },
@@ -73,11 +86,13 @@ export default {
 
 .card {
     width: min(300px, 80vw);
-    justify-content: center;
-    align-items: center;
     display: flex;
+    flex-direction: column;
+    align-items: stretch;
     position: relative;
     z-index: 0;
+    gap: 12px;
+    padding-bottom: 12px;
 }
 
 .image {
@@ -89,19 +104,21 @@ export default {
 .date {
     font-size: 20px;
     color: gray;
+    padding: 0 20px;
 }
 
 .title{ 
     font-size: 20px;
-    margin: 0px 20px 10px 20px;
+    padding: 0 20px;
     text-align: justify;
     line-height: 20px;
+    min-height: 40px;
     color: black
 }
 
 .read_more {
     width: 130px;
-    margin-bottom: 10px;
+    margin: 0 20px;
     border-radius: 20px;
     border: none;
 }
@@ -123,17 +140,21 @@ export default {
 
 .image-container {
     position: relative;
+    margin-bottom: 4px;
 }
 
 .tag {
     position: absolute;
     top: 15px;
+    left: 0;
     z-index: 1;
-    padding: 5px;
+    padding: 5px 10px;
 }
 
 .tagNoImage {
-    padding: 5px;
+    padding: 5px 10px;
+    margin: 0 20px;
+    align-self: flex-start;
 }
 
 </style>

--- a/src/components/cards/PublishedPaperCard.vue
+++ b/src/components/cards/PublishedPaperCard.vue
@@ -1,5 +1,13 @@
 <template>
-    <div class = "card">
+    <div
+        class = "card"
+        :class="{ interactive: clickable }"
+        :role="clickable ? 'button' : undefined"
+        :tabindex="clickable ? 0 : undefined"
+        @click="handleSelect"
+        @keydown.enter.prevent="handleSelect"
+        @keydown.space.prevent="handleSelect"
+    >
         <div class = "text title"> 
         <strong> {{ title }} </strong>
         </div>
@@ -12,7 +20,11 @@
         <i>{{ journal }}</i>
         </div>
 
-        <a v-if="paperLink" class = "doi" :href="paperLink" target="_blank" rel="noopener noreferrer">
+        <div v-if="year" class = "text year">
+            {{ year }}
+        </div>
+
+        <a v-if="paperLink" class = "doi" :href="paperLink" target="_blank" rel="noopener noreferrer" @click.stop>
             <strong> {{ linkLabel }} </strong> 
         </a>
 
@@ -23,6 +35,8 @@
 import research_lab from '/public/research_lab.json';
 
 export default {
+    emits: ['select'],
+
     setup() {
         return
     },
@@ -41,6 +55,18 @@ export default {
         url: String,
         doi: String,
         authors: Array,
+        clickable: {
+            type: Boolean,
+            default: false
+        }
+    },
+
+    methods: {
+        handleSelect() {
+            if (this.clickable) {
+                this.$emit('select');
+            }
+        }
     },
 
     computed: {
@@ -88,6 +114,18 @@ export default {
     width: min(800px, 80vw);
     border: 0px;
     box-shadow: 0 0 10px rgba(0,0,0,0.15);
+}
+
+.card.interactive {
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card.interactive:hover,
+.card.interactive:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(0,0,0,0.18);
+    outline: none;
 }
 
 .text {

--- a/src/lib/adminAuth.js
+++ b/src/lib/adminAuth.js
@@ -1,0 +1,99 @@
+import { isSupabaseConfigured, supabase } from './supabase';
+
+async function getCurrentSession() {
+    if (!isSupabaseConfigured || !supabase) {
+        return null;
+    }
+
+    const { data, error } = await supabase.auth.getSession();
+
+    if (error) {
+        throw error;
+    }
+
+    return data.session;
+}
+
+async function getCurrentUser() {
+    const session = await getCurrentSession();
+    return session?.user || null;
+}
+
+async function getAdminProfile() {
+    const user = await getCurrentUser();
+
+    if (!user || !supabase) {
+        return null;
+    }
+
+    const { data, error } = await supabase
+        .from('profiles')
+        .select('id, email, full_name, is_admin')
+        .eq('id', user.id)
+        .maybeSingle();
+
+    if (error) {
+        throw error;
+    }
+
+    return data;
+}
+
+export async function requireAdminSession() {
+    if (!isSupabaseConfigured || !supabase) {
+        return { ok: false, reason: 'missing-config' };
+    }
+
+    const user = await getCurrentUser();
+
+    if (!user) {
+        return { ok: false, reason: 'signed-out' };
+    }
+
+    const profile = await getAdminProfile();
+
+    if (!profile?.is_admin) {
+        return { ok: false, reason: 'not-admin' };
+    }
+
+    return { ok: true, user, profile };
+}
+
+export async function signInAdmin(email, password) {
+    if (!supabase) {
+        throw new Error('Supabase is not configured.');
+    }
+
+    const { data, error } = await supabase.auth.signInWithPassword({
+        email,
+        password
+    });
+
+    if (error) {
+        throw error;
+    }
+
+    return data;
+}
+
+export async function signOutAdmin() {
+    if (!supabase) {
+        return;
+    }
+
+    const { error } = await supabase.auth.signOut();
+
+    if (error) {
+        throw error;
+    }
+}
+
+export async function getAdminContext() {
+    const session = await getCurrentSession();
+    const profile = await getAdminProfile();
+
+    return {
+        session,
+        profile
+    };
+}

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,0 +1,15 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+export const isSupabaseConfigured = Boolean(supabaseUrl && supabaseAnonKey);
+
+export const supabase = isSupabaseConfigured
+    ? createClient(supabaseUrl, supabaseAnonKey, {
+        auth: {
+            persistSession: true,
+            autoRefreshToken: true
+        }
+    })
+    : null;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -11,6 +11,12 @@ import Researcher from '../views/Researcher.vue';
 import Publications from '../views/Publications.vue';
 import PublicationDetail from '../views/PublicationDetail.vue';
 import News from '../views/News.vue';
+import AdminLogin from '../views/admin/AdminLogin.vue';
+import AdminLayout from '../views/admin/AdminLayout.vue';
+import AdminDashboard from '../views/admin/AdminDashboard.vue';
+import AdminNews from '../views/admin/AdminNews.vue';
+import AdminPeople from '../views/admin/AdminPeople.vue';
+import { requireAdminSession } from '../lib/adminAuth';
 
 const router = createRouter({
     history: createWebHistory(import.meta.env.BASE_URL),
@@ -55,10 +61,69 @@ const router = createRouter({
             path: '/news/:news_id',
             name: 'news',
             component: News,
+        },
+        {
+            path: '/admin/login',
+            name: 'admin-login',
+            component: AdminLogin,
+            meta: {
+                hideSiteChrome: true
+            }
+        },
+        {
+            path: '/admin',
+            component: AdminLayout,
+            meta: {
+                requiresAdminAuth: true,
+                hideSiteChrome: true
+            },
+            children: [
+                {
+                    path: '',
+                    name: 'admin-dashboard',
+                    component: AdminDashboard,
+                    meta: {
+                        requiresAdminAuth: true,
+                        hideSiteChrome: true
+                    }
+                },
+                {
+                    path: 'news',
+                    name: 'admin-news',
+                    component: AdminNews,
+                    meta: {
+                        requiresAdminAuth: true,
+                        hideSiteChrome: true
+                    }
+                },
+                {
+                    path: 'people',
+                    name: 'admin-people',
+                    component: AdminPeople,
+                    meta: {
+                        requiresAdminAuth: true,
+                        hideSiteChrome: true
+                    }
+                }
+            ]
         }
     ],
 })
-router.beforeEach((to, from, next) => {
+router.beforeEach(async (to, from, next) => {
+    if (to.meta?.requiresAdminAuth) {
+        const authState = await requireAdminSession();
+
+        if (!authState.ok) {
+            next({
+                name: 'admin-login',
+                query: {
+                    redirect: to.fullPath
+                }
+            });
+            return;
+        }
+    }
+
     window.scrollTo(0, 0)
     next()
 })

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,6 +9,7 @@ import Research from '../views/Research.vue';
 import Project from '../views/Project.vue';
 import Researcher from '../views/Researcher.vue';
 import Publications from '../views/Publications.vue';
+import PublicationDetail from '../views/PublicationDetail.vue';
 import News from '../views/News.vue';
 
 const router = createRouter({
@@ -44,6 +45,11 @@ const router = createRouter({
             path: '/publications/',
             name: 'publications',
             component: Publications,
+        },
+        {
+            path: '/publications/:publication_id',
+            name: 'publication-detail',
+            component: PublicationDetail,
         },
         {
             path: '/news/:news_id',

--- a/src/views/News.vue
+++ b/src/views/News.vue
@@ -17,7 +17,7 @@
 
 import NavBar from '../components/NavBar.vue';
 import research_lab from '../../public/research_lab.json';
-import NewsResource from '../api/resource/news';
+import NewsResource, { resolveNewsImageUrl } from '../api/resource/news';
 
 export default {
     name: 'News',
@@ -44,7 +44,7 @@ export default {
                 this.person = result.person;
                 this.tag = result.tag;
                 this.description = result.description;
-                this.image = "../" + result.image;
+                this.image = resolveNewsImageUrl(result.image);
 
                 // Apply styles after setting the description
                 this.applyStyles();

--- a/src/views/People.vue
+++ b/src/views/People.vue
@@ -35,7 +35,7 @@
                     class = "search_bar"
                 >
                 
-                <button @click="inputTerm ? resetSearch() : search" class="button search_button">
+                <button @click="inputTerm ? resetSearch() : search" class="button search_button" :style="{ backgroundColor: primary_color }">
                     <img :src="inputTerm ? 'icons/remove.png' : 'icons/search.png'" :alt="inputTerm ? 'Clean' : 'Search'" class="button-icon">
                 </button>
             </div>
@@ -293,7 +293,6 @@ export default {
     width: 50px;
     border-radius: 30px 30px 30px 30px;
     padding: 0;
-    background-color: var(--primary-color)
 }
 
 .role_filter {

--- a/src/views/People.vue
+++ b/src/views/People.vue
@@ -15,7 +15,7 @@
                 <ProfessorCard
                 v-for="member in professors"
                 :key="member.email"
-                :image="member.photos.photo_with_background"
+                :image="resolvePhotoUrl(member.photos.photo_with_background)"
                 :first_name="member.firstName"
                 :last_name="member.lastName"
                 :email="member.contacts.email"
@@ -61,7 +61,7 @@
                 <StudentCard
                 v-for="member in filteredStudents"
                 :key="member.email"
-                :image="member.photos.photo_with_background"
+                :image="resolvePhotoUrl(member.photos.photo_with_background)"
                 :first_name="member.firstName"
                 :last_name="member.lastName"
                 :email="member.contacts.email"
@@ -78,7 +78,7 @@ import ProfessorCard from '../components/cards/ProfessorCard.vue';
 import StudentCard from '../components/cards/StudentCard.vue';
 
 import research_lab from '/public/research_lab.json';
-import MembersResource from '../api/resource/people'
+import MembersResource, { resolveMemberImageUrl } from '../api/resource/people'
 
 export default {
     name: 'People',
@@ -136,6 +136,10 @@ export default {
         resetSearch() {
             this.inputTerm = '';
             this.searchTerm = '';
+        },
+
+        resolvePhotoUrl(imagePath) {
+            return resolveMemberImageUrl(imagePath);
         }
     },
 

--- a/src/views/Project.vue
+++ b/src/views/Project.vue
@@ -38,7 +38,7 @@
                 :key="member.email"
                 :first_name="member.firstName"
                 :last_name="member.lastName"
-                :image="'../' + member.photos.photo_with_background"
+                :image="resolvePhotoUrl(member.photos.photo_with_background)"
                 :email="member.contacts.email"
                 :github="member.contacts.github"
                 :role="member.role"
@@ -55,6 +55,7 @@ import ProjectMemberCard from '../components/cards/ProjectMemberCard.vue';
 import KeyWordsCard from '../components/cards/KeyWordsCard.vue';
 
 import ProjectsResource from '../api/resource/projects'
+import { resolveMemberImageUrl } from '../api/resource/people'
 
 export default  {
     name: 'Project',
@@ -114,6 +115,10 @@ export default  {
                 }, Math.random() * 5000 + 5000); 
             });
         },
+
+        resolvePhotoUrl(imagePath) {
+            return resolveMemberImageUrl(imagePath);
+        }
     },
 
     created() {

--- a/src/views/PublicationDetail.vue
+++ b/src/views/PublicationDetail.vue
@@ -1,0 +1,342 @@
+<template>
+    <div class="publication_page">
+        <div class="hero" :style="{ backgroundColor: primary_color }">
+            <div class="hero_content">
+                <button class="back_button" @click="goBack">
+                    Back to Publications
+                </button>
+
+                <p class="eyebrow" :style="{ color: secundary_color }"> PUBLICATION DETAIL </p>
+                <p class="title">{{ article?.title || 'Loading publication...' }}</p>
+
+                <p v-if="article" class="meta">
+                    {{ authorLine }}
+                </p>
+
+                <p v-if="article" class="meta">
+                    {{ venueLine }}
+                </p>
+            </div>
+        </div>
+
+        <div class="content">
+            <div v-if="isLoading" class="status_card">
+                Loading publication details...
+            </div>
+
+            <div v-else-if="errorMessage" class="status_card">
+                {{ errorMessage }}
+            </div>
+
+            <template v-else-if="article">
+                <div class="info_card">
+                    <p class="section_title"> Overview </p>
+
+                    <div class="overview_grid">
+                        <div class="overview_item">
+                            <span class="overview_label">Year</span>
+                            <span>{{ publicationYear || 'Not available' }}</span>
+                        </div>
+
+                        <div class="overview_item">
+                            <span class="overview_label">DOI</span>
+                            <a v-if="article.DOI" :href="doiLink" target="_blank" rel="noopener noreferrer">{{ article.DOI }}</a>
+                            <span v-else>Not available</span>
+                        </div>
+
+                        <div class="overview_item">
+                            <span class="overview_label">Venue</span>
+                            <span>{{ article['container-title'] || 'Not available' }}</span>
+                        </div>
+
+                        <div class="overview_item">
+                            <span class="overview_label">Abstract</span>
+                            <span>{{ article.abstract ? 'Available below' : 'Not available' }}</span>
+                        </div>
+                    </div>
+
+                    <div class="button_row">
+                        <a v-if="article.landingPageUrl" class="action_button" :href="article.landingPageUrl" target="_blank" rel="noopener noreferrer">
+                            Open Publisher Page
+                        </a>
+
+                        <a v-if="article.pdfUrl" class="action_button secondary" :href="article.pdfUrl" target="_blank" rel="noopener noreferrer">
+                            Open PDF
+                        </a>
+                    </div>
+                </div>
+
+                <div class="info_card">
+                    <p class="section_title"> Abstract </p>
+                    <p class="body_text">
+                        {{ article.abstract || 'An abstract was not available from the connected metadata source for this publication.' }}
+                    </p>
+                </div>
+
+                <div class="info_card">
+                    <p class="section_title"> PDF Preview </p>
+                    <div v-if="article.pdfUrl" class="pdf_panel">
+                        <iframe
+                            class="pdf_frame"
+                            :src="article.pdfUrl"
+                            title="Publication PDF preview"
+                        />
+                        <p class="helper_text">
+                            Some publishers block embedded PDF previews. If the frame stays blank, use the Open PDF button above.
+                        </p>
+                    </div>
+
+                    <p v-else class="body_text">
+                        No direct PDF URL was available for this publication.
+                    </p>
+                </div>
+            </template>
+        </div>
+    </div>
+</template>
+
+<script>
+import research_lab from '../../public/research_lab.json';
+import ArticlesResource from '../api/resource/articles';
+
+export default {
+    name: 'PublicationDetail',
+
+    data() {
+        return {
+            primary_color: research_lab.color_pallete.primary_color,
+            secundary_color: research_lab.color_pallete.secundary_color,
+            article: null,
+            isLoading: true,
+            errorMessage: ''
+        };
+    },
+
+    computed: {
+        publicationYear() {
+            return this.article?.issued?.['date-parts']?.[0]?.[0] || '';
+        },
+
+        doiLink() {
+            return this.article?.DOI ? `https://doi.org/${this.article.DOI}` : '';
+        },
+
+        authorLine() {
+            if (!Array.isArray(this.article?.author) || this.article.author.length === 0) {
+                return 'Authors not available';
+            }
+
+            return this.article.author
+                .map((author) => `${author.given || ''} ${author.family || ''}`.trim())
+                .join(', ');
+        },
+
+        venueLine() {
+            const venue = this.article?.['container-title'] || 'Venue not available';
+            const year = this.publicationYear;
+
+            return year ? `${venue} - ${year}` : venue;
+        }
+    },
+
+    methods: {
+        async loadArticle() {
+            this.isLoading = true;
+            this.errorMessage = '';
+
+            try {
+                const article = await ArticlesResource.getArticleDetailsById(this.$route.params.publication_id);
+
+                if (!article) {
+                    this.errorMessage = 'We could not find that publication.';
+                    return;
+                }
+
+                this.article = article;
+            } catch (error) {
+                console.error('An error occurred:', error);
+                this.errorMessage = 'The publication details could not be loaded right now.';
+            } finally {
+                this.isLoading = false;
+            }
+        },
+
+        goBack() {
+            if (window.history.length > 1) {
+                this.$router.back();
+                return;
+            }
+
+            this.$router.push({ name: 'publications' });
+        }
+    },
+
+    created() {
+        this.loadArticle();
+    },
+
+    watch: {
+        '$route.params.publication_id'() {
+            this.loadArticle();
+        }
+    }
+}
+</script>
+
+<style scoped>
+@font-face {
+    font-family: 'NATS';
+    src: url('/fonts/NATS-Regular.woff');
+}
+
+* {
+    padding: 0;
+    margin: 0;
+    box-sizing: border-box;
+    font-family: 'NATS', sans-serif;
+    color: black;
+}
+
+.publication_page {
+    min-height: 100vh;
+    background: linear-gradient(180deg, #f4f6f8 0%, #ffffff 40%);
+}
+
+.hero {
+    display: flex;
+    justify-content: center;
+    padding: 32px 16px;
+}
+
+.hero_content {
+    width: min(980px, 100%);
+}
+
+.back_button {
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    background: rgba(255, 255, 255, 0.12);
+    color: white;
+    border-radius: 999px;
+    padding: 10px 16px;
+    cursor: pointer;
+    margin-bottom: 18px;
+}
+
+.eyebrow {
+    font-size: 22px;
+    letter-spacing: 1px;
+}
+
+.title {
+    color: white;
+    font-size: min(11vw, 58px);
+    line-height: 0.95;
+    margin-top: 8px;
+}
+
+.meta {
+    color: white;
+    font-size: 24px;
+    margin-top: 14px;
+}
+
+.content {
+    width: min(980px, calc(100% - 32px));
+    margin: -24px auto 0;
+    padding-bottom: 40px;
+}
+
+.info_card,
+.status_card {
+    background: white;
+    border-radius: 24px;
+    box-shadow: 0 12px 30px rgba(25, 31, 44, 0.08);
+    padding: 24px;
+    margin-bottom: 18px;
+}
+
+.section_title {
+    font-size: 34px;
+    margin-bottom: 18px;
+}
+
+.overview_grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+}
+
+.overview_item {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 16px;
+    border-radius: 18px;
+    background: #f4f6f8;
+}
+
+.overview_label {
+    font-size: 18px;
+    color: #586274;
+}
+
+.button_row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 20px;
+}
+
+.action_button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    min-height: 48px;
+    padding: 0 18px;
+    border-radius: 999px;
+    background: #3c485e;
+    color: white;
+}
+
+.action_button.secondary {
+    background: #d9b44a;
+    color: black;
+}
+
+.body_text,
+.helper_text {
+    font-size: 24px;
+    line-height: 1.2;
+}
+
+.pdf_panel {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.pdf_frame {
+    width: 100%;
+    min-height: 640px;
+    border: 1px solid #d9dfe7;
+    border-radius: 18px;
+    background: #f4f6f8;
+}
+
+@media (max-width: 700px) {
+    .title {
+        font-size: min(13vw, 44px);
+    }
+
+    .meta,
+    .body_text,
+    .helper_text {
+        font-size: 20px;
+    }
+
+    .pdf_frame {
+        min-height: 460px;
+    }
+}
+</style>

--- a/src/views/Publications.vue
+++ b/src/views/Publications.vue
@@ -22,13 +22,15 @@
         <div v-else class = "published_paper_container">
             <PublishedPaperCard
                 v-for="paper in filteredPapers"
-                :key="paper.DOI || `${paper.title}-${paper.issued?.['date-parts']?.[0]?.[0] || 'unknown'}`"
+                :key="paper.id"
                 :title="paper.title"
                 :journal="paper['container-title']"
                 :year="paper.issued?.['date-parts']?.[0]?.[0]"
                 :url="paper.URL"
                 :doi="paper.DOI"
                 :authors="paper.author"
+                :clickable="true"
+                @select="openPublication(paper)"
             />
         </div>
     </div>
@@ -75,6 +77,15 @@ export default {
         resetSearch() {
             this.inputTerm = '';
             this.searchTerm = '';
+        },
+
+        openPublication(paper) {
+            this.$router.push({
+                name: 'publication-detail',
+                params: {
+                    publication_id: paper.id
+                }
+            });
         },
 
         getPaperSearchText(paper) {

--- a/src/views/Publications.vue
+++ b/src/views/Publications.vue
@@ -10,7 +10,7 @@
                 class = "search_bar"
             >
             
-            <button @click="inputTerm ? resetSearch() : search" class="button search_button">
+            <button @click="inputTerm ? resetSearch() : search" class="button search_button" :style="{ backgroundColor: primary_color }">
                 <img :src="inputTerm ? '/icons/remove.png' : '/icons/search.png'" :alt="inputTerm ? 'Clean' : 'Search'" class="button-icon">
             </button>
         </div>
@@ -219,7 +219,6 @@ export default {
     width: 50px;
     border-radius: 30px 30px 30px 30px;
     padding: 0;
-    background-color: var(--primary-color)
 }
 
 .empty_state {

--- a/src/views/Researcher.vue
+++ b/src/views/Researcher.vue
@@ -522,7 +522,6 @@ export default  {
     width: 50px;
     border-radius: 30px 30px 30px 30px;
     padding: 0;
-    background-color: var(--primary-color)
 }
 
 .botaoPaginacao {

--- a/src/views/Researcher.vue
+++ b/src/views/Researcher.vue
@@ -100,13 +100,15 @@
         <div class = "published_paper_container">
             <PublishedPaperCard
                 v-for="paper in paginatedPapers"
-                :key="paper.DOI || `${paper.title}-${paper.issued['date-parts'][0][0]}`"
+                :key="paper.id"
                 :title="paper.title"
                 :journal="paper['container-title']"
                 :year="paper.issued['date-parts'][0][0]"
                 :url="paper.URL"
                 :doi="paper.DOI"
                 :authors="paper.author"
+                :clickable="true"
+                @select="openPublication(paper)"
             />
         </div>
 
@@ -249,6 +251,15 @@ export default  {
 
         changePage(page) {
             this.currentPage = page;
+        },
+
+        openPublication(paper) {
+            this.$router.push({
+                name: 'publication-detail',
+                params: {
+                    publication_id: paper.id
+                }
+            });
         },
 
         capitalizeFirstLetter(string) {

--- a/src/views/Researcher.vue
+++ b/src/views/Researcher.vue
@@ -170,7 +170,7 @@ import research_lab from '../../public/research_lab.json';
 import KeyWordsCard from '../components/cards/KeyWordsCard.vue';
 import PublishedPaperCard from '../components/cards/PublishedPaperCard.vue';
 
-import MembersResource from '../api/resource/people'
+import MembersResource, { resolveMemberImageUrl } from '../api/resource/people'
 import ArticlesResource from '../api/resource/articles'
 
 export default  {
@@ -208,7 +208,7 @@ export default  {
             MembersResource
             .getFirstMemberByName(this.raw_researcher_name)
             .then((result) => {
-                this.image_without_background = '../' + result.photos.photo_without_background;
+                this.image_without_background = resolveMemberImageUrl(result.photos.photo_without_background);
                 this.description = result.description;
                 this.contacts = result.contacts;
                 this.first_name = result.firstName;

--- a/src/views/admin/AdminDashboard.vue
+++ b/src/views/admin/AdminDashboard.vue
@@ -1,0 +1,53 @@
+<template>
+    <section class="dashboard">
+        <div class="hero_card">
+            <p class="eyebrow">Prototype</p>
+            <h1>Admin dashboard</h1>
+            <p>
+                This prototype is wired for Supabase-backed content editing. News CRUD is live, and people editing supports bios, contact links, DBLP IDs, and research keywords.
+            </p>
+        </div>
+
+        <div class="grid">
+            <router-link class="feature_card" to="/admin/news">
+                <h2>Manage news</h2>
+                <p>Add, edit, publish, or remove front-page news posts.</p>
+            </router-link>
+
+            <router-link class="feature_card" to="/admin/people">
+                <h2>Manage people</h2>
+                <p>Update people, research keywords, contacts, and profile metadata.</p>
+            </router-link>
+        </div>
+    </section>
+</template>
+
+<style scoped>
+.dashboard {
+    display: grid;
+    gap: 20px;
+}
+
+.hero_card,
+.feature_card {
+    background: white;
+    border-radius: 24px;
+    padding: 24px;
+    box-shadow: 0 16px 36px rgba(31, 42, 61, 0.08);
+    text-decoration: none;
+    color: inherit;
+}
+
+.grid {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: #6b7586;
+    margin-bottom: 8px;
+}
+</style>

--- a/src/views/admin/AdminLayout.vue
+++ b/src/views/admin/AdminLayout.vue
@@ -1,0 +1,116 @@
+<template>
+    <section class="admin_layout">
+        <aside class="sidebar">
+            <div>
+                <p class="brand">RESHAPE Admin</p>
+                <p v-if="profile" class="profile">{{ profile.full_name || profile.email }}</p>
+            </div>
+
+            <nav class="nav">
+                <router-link to="/admin">Overview</router-link>
+                <router-link to="/admin/news">News</router-link>
+                <router-link to="/admin/people">People</router-link>
+            </nav>
+
+            <button class="sign_out" @click="handleSignOut">Sign out</button>
+        </aside>
+
+        <main class="content">
+            <router-view />
+        </main>
+    </section>
+</template>
+
+<script>
+import { getAdminContext, signOutAdmin } from '../../lib/adminAuth';
+
+export default {
+    name: 'AdminLayout',
+
+    data() {
+        return {
+            profile: null
+        };
+    },
+
+    async created() {
+        const context = await getAdminContext();
+        this.profile = context.profile;
+    },
+
+    methods: {
+        async handleSignOut() {
+            await signOutAdmin();
+            this.$router.push('/admin/login');
+        }
+    }
+}
+</script>
+
+<style scoped>
+.admin_layout {
+    min-height: 100vh;
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    background: #edf2f7;
+}
+
+.sidebar {
+    background: #1f2a3d;
+    color: white;
+    padding: 28px 22px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: 24px;
+}
+
+.brand {
+    font-size: 28px;
+    margin: 0 0 6px;
+}
+
+.profile {
+    color: #c7d2e3;
+    margin: 0;
+}
+
+.nav {
+    display: grid;
+    gap: 10px;
+}
+
+.nav a {
+    color: white;
+    text-decoration: none;
+    padding: 12px 14px;
+    border-radius: 14px;
+}
+
+.nav a.router-link-exact-active {
+    background: rgba(255, 255, 255, 0.12);
+}
+
+.sign_out {
+    min-height: 44px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: transparent;
+    color: white;
+    border-radius: 999px;
+    cursor: pointer;
+}
+
+.content {
+    padding: 28px;
+}
+
+@media (max-width: 900px) {
+    .admin_layout {
+        grid-template-columns: 1fr;
+    }
+
+    .sidebar {
+        gap: 16px;
+    }
+}
+</style>

--- a/src/views/admin/AdminLayout.vue
+++ b/src/views/admin/AdminLayout.vue
@@ -1,9 +1,9 @@
 <template>
     <section class="admin_layout">
         <aside class="sidebar">
-            <div>
+            <div class="sidebar_top">
                 <p class="brand">RESHAPE Admin</p>
-                <p v-if="profile" class="profile">{{ profile.full_name || profile.email }}</p>
+                <p v-if="profile?.email" class="profile">{{ profile.email }}</p>
             </div>
 
             <nav class="nav">
@@ -53,9 +53,13 @@ export default {
     display: grid;
     grid-template-columns: 260px 1fr;
     background: #edf2f7;
+    align-items: start;
 }
 
 .sidebar {
+    position: sticky;
+    top: 0;
+    height: 100vh;
     background: #1f2a3d;
     color: white;
     padding: 28px 22px;
@@ -63,6 +67,13 @@ export default {
     flex-direction: column;
     justify-content: space-between;
     gap: 24px;
+    overflow-y: auto;
+    box-sizing: border-box;
+}
+
+.sidebar_top {
+    display: grid;
+    gap: 6px;
 }
 
 .brand {
@@ -73,6 +84,7 @@ export default {
 .profile {
     color: #c7d2e3;
     margin: 0;
+    word-break: break-word;
 }
 
 .nav {
@@ -102,6 +114,7 @@ export default {
 
 .content {
     padding: 28px;
+    min-width: 0;
 }
 
 @media (max-width: 900px) {
@@ -110,6 +123,8 @@ export default {
     }
 
     .sidebar {
+        position: static;
+        height: auto;
         gap: 16px;
     }
 }

--- a/src/views/admin/AdminLogin.vue
+++ b/src/views/admin/AdminLogin.vue
@@ -1,0 +1,145 @@
+<template>
+    <section class="admin_shell">
+        <div class="auth_card">
+            <p class="eyebrow">RESHAPE Admin</p>
+            <h1>Sign in</h1>
+            <p class="subtitle">
+                Use your Supabase email/password account to manage news and people.
+            </p>
+
+            <p v-if="!isConfigured" class="status error">
+                Supabase is not configured yet. Add `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` before using admin mode.
+            </p>
+
+            <p v-if="errorMessage" class="status error">{{ errorMessage }}</p>
+
+            <form class="auth_form" @submit.prevent="submitLogin">
+                <label>
+                    Email
+                    <input v-model="email" type="email" autocomplete="email" required>
+                </label>
+
+                <label>
+                    Password
+                    <input v-model="password" type="password" autocomplete="current-password" required>
+                </label>
+
+                <button :disabled="isSubmitting || !isConfigured" type="submit">
+                    {{ isSubmitting ? 'Signing in...' : 'Sign in' }}
+                </button>
+            </form>
+        </div>
+    </section>
+</template>
+
+<script>
+import { signInAdmin } from '../../lib/adminAuth';
+import { isSupabaseConfigured } from '../../lib/supabase';
+
+export default {
+    name: 'AdminLogin',
+
+    data() {
+        return {
+            email: '',
+            password: '',
+            errorMessage: '',
+            isSubmitting: false,
+            isConfigured: isSupabaseConfigured
+        };
+    },
+
+    methods: {
+        async submitLogin() {
+            this.errorMessage = '';
+            this.isSubmitting = true;
+
+            try {
+                await signInAdmin(this.email, this.password);
+                this.$router.push(this.$route.query.redirect || '/admin');
+            } catch (error) {
+                this.errorMessage = error.message || 'Unable to sign in.';
+            } finally {
+                this.isSubmitting = false;
+            }
+        }
+    }
+}
+</script>
+
+<style scoped>
+.admin_shell {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    background: linear-gradient(135deg, #f3f6fb 0%, #dbe4ee 100%);
+    padding: 24px;
+}
+
+.auth_card {
+    width: min(460px, 100%);
+    background: white;
+    border-radius: 28px;
+    box-shadow: 0 18px 50px rgba(18, 28, 45, 0.14);
+    padding: 32px;
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: #6b7586;
+    margin-bottom: 10px;
+}
+
+h1 {
+    margin: 0 0 10px;
+}
+
+.subtitle {
+    color: #586274;
+    margin-bottom: 20px;
+}
+
+.auth_form {
+    display: grid;
+    gap: 16px;
+}
+
+label {
+    display: grid;
+    gap: 8px;
+    color: #2b3442;
+}
+
+input {
+    min-height: 46px;
+    border-radius: 14px;
+    border: 1px solid #c9d3df;
+    padding: 0 14px;
+}
+
+button {
+    min-height: 48px;
+    border: 0;
+    border-radius: 999px;
+    background: #3c485e;
+    color: white;
+    cursor: pointer;
+}
+
+button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.status {
+    border-radius: 14px;
+    padding: 12px 14px;
+    margin-bottom: 16px;
+}
+
+.status.error {
+    background: #ffe9e7;
+    color: #8a2d24;
+}
+</style>

--- a/src/views/admin/AdminNews.vue
+++ b/src/views/admin/AdminNews.vue
@@ -13,9 +13,14 @@
             <p v-if="statusMessage" class="status">{{ statusMessage }}</p>
             <p v-if="errorMessage" class="status error">{{ errorMessage }}</p>
 
+            <label class="search_field">
+                Search news titles
+                <input v-model="searchTerm" placeholder="Search by title...">
+            </label>
+
             <div class="table_like">
                 <button
-                    v-for="item in newsItems"
+                    v-for="item in filteredNewsItems"
                     :key="item.id"
                     class="row_button"
                     @click="selectItem(item)"
@@ -136,6 +141,7 @@ export default {
     data() {
         return {
             newsItems: [],
+            searchTerm: '',
             form: emptyForm(),
             peopleInput: '',
             isCreating: true,
@@ -150,6 +156,18 @@ export default {
     computed: {
         imagePreviewUrl() {
             return resolveNewsImageUrl(this.form.image);
+        },
+
+        filteredNewsItems() {
+            const normalizedSearch = this.searchTerm.trim().toLowerCase();
+
+            if (!normalizedSearch) {
+                return this.newsItems;
+            }
+
+            return this.newsItems.filter((item) => {
+                return `${item.title || ''}`.toLowerCase().includes(normalizedSearch);
+            });
         }
     },
 
@@ -369,6 +387,10 @@ button {
 }
 
 .table_like {
+    margin-top: 18px;
+}
+
+.search_field {
     margin-top: 18px;
 }
 

--- a/src/views/admin/AdminNews.vue
+++ b/src/views/admin/AdminNews.vue
@@ -35,7 +35,7 @@
             <form class="editor_form" @submit.prevent="saveItem">
                 <label>
                     ID
-                    <input v-model="form.id" required>
+                    <input v-model="form.id" placeholder="YYYYMMDD_KEYWORD" required>
                 </label>
 
                 <label>
@@ -56,9 +56,39 @@
                 </div>
 
                 <label>
-                    Image path
-                    <input v-model="form.image" placeholder="images/posts/example.png">
+                    Upload image
+                    <input
+                        ref="imageInput"
+                        type="file"
+                        accept="image/*"
+                        @change="handleImageSelection"
+                    >
                 </label>
+
+                <div class="upload_row">
+                    <button
+                        type="button"
+                        class="tertiary"
+                        :disabled="!selectedImageFile || isUploadingImage"
+                        @click="uploadSelectedImage"
+                    >
+                        {{ isUploadingImage ? 'Uploading...' : 'Upload image' }}
+                    </button>
+                    <p v-if="selectedImageFile" class="file_name">{{ selectedImageFile.name }}</p>
+                </div>
+
+                <p class="help_text">
+                    Uploaded images are stored in the Supabase Storage bucket `news-images` and their path is filled in automatically.
+                </p>
+
+                <label>
+                    Image path or URL
+                    <input v-model="form.image" placeholder="news-images/post-id/file.png">
+                </label>
+
+                <div v-if="imagePreviewUrl" class="image_preview">
+                    <img :src="imagePreviewUrl" alt="News image preview">
+                </div>
 
                 <label>
                     People
@@ -67,7 +97,7 @@
 
                 <label>
                     Description HTML
-                    <textarea v-model="form.description" rows="10"></textarea>
+                    <textarea v-model="form.description" placeholder="<p>Start writing using HTML tags...<p>" rows="10"></textarea>
                 </label>
 
                 <label class="checkbox">
@@ -85,7 +115,7 @@
 </template>
 
 <script>
-import NewsResource from '../../api/resource/news';
+import NewsResource, { resolveNewsImageUrl } from '../../api/resource/news';
 
 function emptyForm() {
     return {
@@ -110,9 +140,17 @@ export default {
             peopleInput: '',
             isCreating: true,
             isSaving: false,
+            isUploadingImage: false,
             statusMessage: '',
-            errorMessage: ''
+            errorMessage: '',
+            selectedImageFile: null
         };
+    },
+
+    computed: {
+        imagePreviewUrl() {
+            return resolveNewsImageUrl(this.form.image);
+        }
     },
 
     async created() {
@@ -128,16 +166,66 @@ export default {
             this.form = emptyForm();
             this.peopleInput = '';
             this.isCreating = true;
+            this.isUploadingImage = false;
             this.statusMessage = '';
             this.errorMessage = '';
+            this.selectedImageFile = null;
+
+            if (this.$refs.imageInput) {
+                this.$refs.imageInput.value = '';
+            }
         },
 
         selectItem(item) {
             this.form = { ...item };
             this.peopleInput = (item.person || []).join(', ');
             this.isCreating = false;
+            this.isUploadingImage = false;
             this.statusMessage = '';
             this.errorMessage = '';
+            this.selectedImageFile = null;
+
+            if (this.$refs.imageInput) {
+                this.$refs.imageInput.value = '';
+            }
+        },
+
+        handleImageSelection(event) {
+            const [file] = event.target.files || [];
+            this.selectedImageFile = file || null;
+        },
+
+        async uploadSelectedImage(options = {}) {
+            if (!this.selectedImageFile) {
+                return;
+            }
+
+            if (!this.form.id?.trim()) {
+                this.errorMessage = 'Add the post ID before uploading an image so the file can be organized correctly.';
+                return;
+            }
+
+            this.isUploadingImage = true;
+            this.errorMessage = '';
+
+            try {
+                const { filePath } = await NewsResource.uploadNewsImage(this.selectedImageFile, this.form.id);
+                this.form.image = filePath;
+                this.selectedImageFile = null;
+
+                if (this.$refs.imageInput) {
+                    this.$refs.imageInput.value = '';
+                }
+
+                if (!options.preserveStatusMessage) {
+                    this.statusMessage = 'Image uploaded. Save the news post to attach it permanently.';
+                }
+            } catch (error) {
+                this.errorMessage = error.message || 'Unable to upload the image.';
+                throw error;
+            } finally {
+                this.isUploadingImage = false;
+            }
         },
 
         async saveItem() {
@@ -146,6 +234,12 @@ export default {
             this.errorMessage = '';
 
             try {
+                if (this.selectedImageFile) {
+                    await this.uploadSelectedImage({
+                        preserveStatusMessage: true
+                    });
+                }
+
                 const payload = {
                     ...this.form,
                     person: this.peopleInput
@@ -199,7 +293,8 @@ export default {
 
 .panel_header,
 .action_row,
-.two_col {
+.two_col,
+.upload_row {
     display: flex;
     gap: 12px;
 }
@@ -251,6 +346,15 @@ button {
     background: #8a2d24;
 }
 
+.tertiary {
+    background: #2b6a8b;
+}
+
+.tertiary:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
 .row_button {
     width: 100%;
     display: flex;
@@ -286,6 +390,27 @@ button {
     align-items: center;
 }
 
+.help_text,
+.file_name {
+    margin: 0;
+    color: #586274;
+    font-size: 14px;
+}
+
+.image_preview {
+    border: 1px solid #d6dee8;
+    border-radius: 18px;
+    overflow: hidden;
+    background: #f8fbfd;
+}
+
+.image_preview img {
+    display: block;
+    width: 100%;
+    max-height: 260px;
+    object-fit: cover;
+}
+
 .eyebrow {
     text-transform: uppercase;
     letter-spacing: 0.12em;
@@ -300,6 +425,11 @@ button {
 
     .two_col {
         flex-direction: column;
+    }
+
+    .upload_row {
+        flex-direction: column;
+        align-items: flex-start;
     }
 }
 </style>

--- a/src/views/admin/AdminNews.vue
+++ b/src/views/admin/AdminNews.vue
@@ -1,0 +1,305 @@
+<template>
+    <section class="admin_page">
+        <div class="panel">
+            <div class="panel_header">
+                <div>
+                    <p class="eyebrow">Content</p>
+                    <h1>News</h1>
+                </div>
+
+                <button @click="startCreate">New post</button>
+            </div>
+
+            <p v-if="statusMessage" class="status">{{ statusMessage }}</p>
+            <p v-if="errorMessage" class="status error">{{ errorMessage }}</p>
+
+            <div class="table_like">
+                <button
+                    v-for="item in newsItems"
+                    :key="item.id"
+                    class="row_button"
+                    @click="selectItem(item)"
+                >
+                    <div>
+                        <strong>{{ item.title }}</strong>
+                        <p>{{ item.date }} · {{ item.tag || 'UNTAGGED' }}</p>
+                    </div>
+                    <span>{{ item.published ? 'Published' : 'Draft' }}</span>
+                </button>
+            </div>
+        </div>
+
+        <div class="panel">
+            <h2>{{ isCreating ? 'Create news post' : 'Edit news post' }}</h2>
+
+            <form class="editor_form" @submit.prevent="saveItem">
+                <label>
+                    ID
+                    <input v-model="form.id" required>
+                </label>
+
+                <label>
+                    Title
+                    <input v-model="form.title" required>
+                </label>
+
+                <div class="two_col">
+                    <label>
+                        Date
+                        <input v-model="form.date" placeholder="YYYY-MM-DD or YYYY-MM">
+                    </label>
+
+                    <label>
+                        Tag
+                        <input v-model="form.tag">
+                    </label>
+                </div>
+
+                <label>
+                    Image path
+                    <input v-model="form.image" placeholder="images/posts/example.png">
+                </label>
+
+                <label>
+                    People
+                    <input v-model="peopleInput" placeholder="comma,separated,names">
+                </label>
+
+                <label>
+                    Description HTML
+                    <textarea v-model="form.description" rows="10"></textarea>
+                </label>
+
+                <label class="checkbox">
+                    <input v-model="form.published" type="checkbox">
+                    Published
+                </label>
+
+                <div class="action_row">
+                    <button type="submit">{{ isSaving ? 'Saving...' : 'Save' }}</button>
+                    <button v-if="!isCreating" type="button" class="secondary" @click="removeItem">Delete</button>
+                </div>
+            </form>
+        </div>
+    </section>
+</template>
+
+<script>
+import NewsResource from '../../api/resource/news';
+
+function emptyForm() {
+    return {
+        id: '',
+        title: '',
+        date: '',
+        person: [],
+        tag: '',
+        image: '',
+        description: '',
+        published: true
+    };
+}
+
+export default {
+    name: 'AdminNews',
+
+    data() {
+        return {
+            newsItems: [],
+            form: emptyForm(),
+            peopleInput: '',
+            isCreating: true,
+            isSaving: false,
+            statusMessage: '',
+            errorMessage: ''
+        };
+    },
+
+    async created() {
+        await this.loadNews();
+    },
+
+    methods: {
+        async loadNews() {
+            this.newsItems = await NewsResource.getAdminNews();
+        },
+
+        startCreate() {
+            this.form = emptyForm();
+            this.peopleInput = '';
+            this.isCreating = true;
+            this.statusMessage = '';
+            this.errorMessage = '';
+        },
+
+        selectItem(item) {
+            this.form = { ...item };
+            this.peopleInput = (item.person || []).join(', ');
+            this.isCreating = false;
+            this.statusMessage = '';
+            this.errorMessage = '';
+        },
+
+        async saveItem() {
+            this.isSaving = true;
+            this.statusMessage = '';
+            this.errorMessage = '';
+
+            try {
+                const payload = {
+                    ...this.form,
+                    person: this.peopleInput
+                        .split(',')
+                        .map((name) => name.trim())
+                        .filter(Boolean)
+                };
+
+                const savedItem = await NewsResource.upsertNewsItem(payload);
+                await this.loadNews();
+                this.selectItem(savedItem);
+                this.statusMessage = 'News item saved.';
+            } catch (error) {
+                this.errorMessage = error.message || 'Unable to save the news item.';
+            } finally {
+                this.isSaving = false;
+            }
+        },
+
+        async removeItem() {
+            if (!this.form.id) {
+                return;
+            }
+
+            try {
+                await NewsResource.deleteNewsItem(this.form.id);
+                await this.loadNews();
+                this.startCreate();
+                this.statusMessage = 'News item deleted.';
+            } catch (error) {
+                this.errorMessage = error.message || 'Unable to delete the news item.';
+            }
+        }
+    }
+}
+</script>
+
+<style scoped>
+.admin_page {
+    display: grid;
+    grid-template-columns: minmax(300px, 420px) minmax(0, 1fr);
+    gap: 20px;
+}
+
+.panel {
+    background: white;
+    border-radius: 24px;
+    padding: 24px;
+    box-shadow: 0 16px 36px rgba(31, 42, 61, 0.08);
+}
+
+.panel_header,
+.action_row,
+.two_col {
+    display: flex;
+    gap: 12px;
+}
+
+.panel_header,
+.action_row {
+    justify-content: space-between;
+    align-items: center;
+}
+
+.editor_form {
+    display: grid;
+    gap: 14px;
+}
+
+.two_col > label {
+    flex: 1;
+}
+
+label {
+    display: grid;
+    gap: 8px;
+}
+
+input,
+textarea,
+button {
+    font: inherit;
+}
+
+input,
+textarea {
+    border: 1px solid #c9d3df;
+    border-radius: 14px;
+    padding: 12px 14px;
+}
+
+button {
+    min-height: 44px;
+    border: 0;
+    border-radius: 999px;
+    padding: 0 16px;
+    background: #3c485e;
+    color: white;
+    cursor: pointer;
+}
+
+.secondary {
+    background: #8a2d24;
+}
+
+.row_button {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    text-align: left;
+    background: #f5f8fb;
+    color: black;
+    border-radius: 18px;
+    margin-bottom: 10px;
+    padding: 14px 16px;
+}
+
+.table_like {
+    margin-top: 18px;
+}
+
+.status {
+    background: #e6f4ea;
+    color: #24613f;
+    border-radius: 14px;
+    padding: 12px 14px;
+    margin-top: 14px;
+}
+
+.status.error {
+    background: #ffe9e7;
+    color: #8a2d24;
+}
+
+.checkbox {
+    grid-template-columns: auto 1fr;
+    align-items: center;
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: #6b7586;
+    margin-bottom: 8px;
+}
+
+@media (max-width: 980px) {
+    .admin_page {
+        grid-template-columns: 1fr;
+    }
+
+    .two_col {
+        flex-direction: column;
+    }
+}
+</style>

--- a/src/views/admin/AdminNews.vue
+++ b/src/views/admin/AdminNews.vue
@@ -142,6 +142,7 @@ export default {
         return {
             newsItems: [],
             searchTerm: '',
+            originalId: '',
             form: emptyForm(),
             peopleInput: '',
             isCreating: true,
@@ -182,6 +183,7 @@ export default {
 
         startCreate() {
             this.form = emptyForm();
+            this.originalId = '';
             this.peopleInput = '';
             this.isCreating = true;
             this.isUploadingImage = false;
@@ -196,6 +198,7 @@ export default {
 
         selectItem(item) {
             this.form = { ...item };
+            this.originalId = item.id;
             this.peopleInput = (item.person || []).join(', ');
             this.isCreating = false;
             this.isUploadingImage = false;
@@ -266,7 +269,9 @@ export default {
                         .filter(Boolean)
                 };
 
-                const savedItem = await NewsResource.upsertNewsItem(payload);
+                const savedItem = this.isCreating
+                    ? await NewsResource.upsertNewsItem(payload)
+                    : await NewsResource.updateNewsItem(this.originalId || this.form.id, payload);
                 await this.loadNews();
                 this.selectItem(savedItem);
                 this.statusMessage = 'News item saved.';

--- a/src/views/admin/AdminNews.vue
+++ b/src/views/admin/AdminNews.vue
@@ -95,9 +95,26 @@
                     <img :src="imagePreviewUrl" alt="News image preview">
                 </div>
 
-                <label>
+                <label class="people_field">
                     People
-                    <input v-model="peopleInput" placeholder="comma,separated,names">
+                    <input
+                        ref="peopleInput"
+                        v-model="peopleInput"
+                        placeholder="comma,separated,names"
+                        @focus="isPeopleInputFocused = true"
+                        @blur="handlePeopleInputBlur"
+                    >
+                    <div v-if="showPeopleSuggestions" class="suggestions_list">
+                        <button
+                            v-for="person in filteredPeopleSuggestions"
+                            :key="person.slug"
+                            type="button"
+                            class="suggestion_item"
+                            @mousedown.prevent="applyPersonSuggestion(person)"
+                        >
+                            {{ person.firstName }} {{ person.lastName }}
+                        </button>
+                    </div>
                 </label>
 
                 <label>
@@ -121,6 +138,7 @@
 
 <script>
 import NewsResource, { resolveNewsImageUrl } from '../../api/resource/news';
+import MembersResource from '../../api/resource/people';
 
 function emptyForm() {
     return {
@@ -141,10 +159,12 @@ export default {
     data() {
         return {
             newsItems: [],
+            peopleOptions: [],
             searchTerm: '',
             originalId: '',
             form: emptyForm(),
             peopleInput: '',
+            isPeopleInputFocused: false,
             isCreating: true,
             isSaving: false,
             isUploadingImage: false,
@@ -169,11 +189,44 @@ export default {
             return this.newsItems.filter((item) => {
                 return `${item.title || ''}`.toLowerCase().includes(normalizedSearch);
             });
+        },
+
+        currentPeopleSearchTerm() {
+            const segments = this.peopleInput.split(',');
+            return (segments[segments.length - 1] || '').trim().toLowerCase();
+        },
+
+        filteredPeopleSuggestions() {
+            const currentSearch = this.currentPeopleSearchTerm;
+
+            if (!currentSearch) {
+                return [];
+            }
+
+            const alreadySelectedNames = this.peopleInput
+                .split(',')
+                .slice(0, -1)
+                .map((name) => name.trim().toLowerCase())
+                .filter(Boolean);
+
+            return this.peopleOptions
+                .filter((person) => {
+                    const fullName = `${person.firstName || ''} ${person.lastName || ''}`.trim();
+                    const normalizedName = fullName.toLowerCase();
+
+                    return normalizedName.includes(currentSearch) && !alreadySelectedNames.includes(normalizedName);
+                })
+                .slice(0, 6);
+        },
+
+        showPeopleSuggestions() {
+            return this.isPeopleInputFocused && this.filteredPeopleSuggestions.length > 0;
         }
     },
 
     async created() {
         await this.loadNews();
+        await this.loadPeopleOptions();
     },
 
     methods: {
@@ -181,10 +234,15 @@ export default {
             this.newsItems = await NewsResource.getAdminNews();
         },
 
+        async loadPeopleOptions() {
+            this.peopleOptions = await MembersResource.getAdminMembers();
+        },
+
         startCreate() {
             this.form = emptyForm();
             this.originalId = '';
             this.peopleInput = '';
+            this.isPeopleInputFocused = false;
             this.isCreating = true;
             this.isUploadingImage = false;
             this.statusMessage = '';
@@ -200,6 +258,7 @@ export default {
             this.form = { ...item };
             this.originalId = item.id;
             this.peopleInput = (item.person || []).join(', ');
+            this.isPeopleInputFocused = false;
             this.isCreating = false;
             this.isUploadingImage = false;
             this.statusMessage = '';
@@ -214,6 +273,21 @@ export default {
         handleImageSelection(event) {
             const [file] = event.target.files || [];
             this.selectedImageFile = file || null;
+        },
+
+        handlePeopleInputBlur() {
+            window.setTimeout(() => {
+                this.isPeopleInputFocused = false;
+            }, 100);
+        },
+
+        applyPersonSuggestion(person) {
+            const fullName = `${person.firstName || ''} ${person.lastName || ''}`.trim();
+            const segments = this.peopleInput.split(',');
+
+            segments[segments.length - 1] = ` ${fullName}`;
+            this.peopleInput = `${segments.join(',').replace(/^\s+/, '').trim()}, `;
+            this.isPeopleInputFocused = true;
         },
 
         async uploadSelectedImage(options = {}) {
@@ -397,6 +471,41 @@ button {
 
 .search_field {
     margin-top: 18px;
+}
+
+.people_field {
+    position: relative;
+}
+
+.suggestions_list {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    background: white;
+    border: 1px solid #c9d3df;
+    border-radius: 14px;
+    box-shadow: 0 16px 36px rgba(31, 42, 61, 0.12);
+    overflow: hidden;
+    z-index: 5;
+}
+
+.suggestion_item {
+    width: 100%;
+    min-height: auto;
+    padding: 12px 14px;
+    border-radius: 0;
+    background: white;
+    color: #1f2a3d;
+    text-align: left;
+}
+
+.suggestion_item + .suggestion_item {
+    border-top: 1px solid #e4e9f0;
+}
+
+.suggestion_item:hover {
+    background: #f5f8fb;
 }
 
 .status {

--- a/src/views/admin/AdminPeople.vue
+++ b/src/views/admin/AdminPeople.vue
@@ -1,0 +1,345 @@
+<template>
+    <section class="admin_page">
+        <div class="panel">
+            <div class="panel_header">
+                <div>
+                    <p class="eyebrow">Content</p>
+                    <h1>People</h1>
+                </div>
+
+                <button @click="startCreate">New person</button>
+            </div>
+
+            <p v-if="statusMessage" class="status">{{ statusMessage }}</p>
+            <p v-if="errorMessage" class="status error">{{ errorMessage }}</p>
+
+            <div class="table_like">
+                <button
+                    v-for="member in members"
+                    :key="member.slug"
+                    class="row_button"
+                    @click="selectMember(member)"
+                >
+                    <div>
+                        <strong>{{ member.firstName }} {{ member.lastName }}</strong>
+                        <p>{{ member.role }}</p>
+                    </div>
+                    <span>{{ member.slug }}</span>
+                </button>
+            </div>
+        </div>
+
+        <div class="panel">
+            <h2>{{ isCreating ? 'Create person' : 'Edit person' }}</h2>
+
+            <form class="editor_form" @submit.prevent="saveMember">
+                <div class="two_col">
+                    <label>
+                        First name
+                        <input v-model="form.firstName" required>
+                    </label>
+
+                    <label>
+                        Last name
+                        <input v-model="form.lastName" required>
+                    </label>
+                </div>
+
+                <div class="two_col">
+                    <label>
+                        Slug
+                        <input v-model="form.slug" required>
+                    </label>
+
+                    <label>
+                        Role
+                        <input v-model="form.role" required>
+                    </label>
+                </div>
+
+                <label>
+                    Bio / description
+                    <textarea v-model="form.description" rows="6"></textarea>
+                </label>
+
+                <label>
+                    Research keywords
+                    <input v-model="researchKeywordsInput" placeholder="comma, separated, keywords">
+                </label>
+
+                <label>
+                    Author aliases
+                    <input v-model="authorNamesInput" placeholder="comma, separated, aliases">
+                </label>
+
+                <label>
+                    Projects
+                    <input v-model="projectsInput" placeholder="comma, separated, projects">
+                </label>
+
+                <div class="two_col">
+                    <label>
+                        Email
+                        <input v-model="form.contacts.email">
+                    </label>
+
+                    <label>
+                        GitHub
+                        <input v-model="form.contacts.github">
+                    </label>
+                </div>
+
+                <div class="two_col">
+                    <label>
+                        Photo with background
+                        <input v-model="form.photos.photo_with_background">
+                    </label>
+
+                    <label>
+                        Photo without background
+                        <input v-model="form.photos.photo_without_background">
+                    </label>
+                </div>
+
+                <label>
+                    DBLP PID
+                    <input v-model="form.dblpPid">
+                </label>
+
+                <div class="action_row">
+                    <button type="submit">{{ isSaving ? 'Saving...' : 'Save' }}</button>
+                    <button v-if="!isCreating" type="button" class="secondary" @click="removeMember">Delete</button>
+                </div>
+            </form>
+        </div>
+    </section>
+</template>
+
+<script>
+import MembersResource from '../../api/resource/people';
+
+function emptyMember() {
+    return {
+        firstName: '',
+        lastName: '',
+        slug: '',
+        role: '',
+        description: '',
+        research_keywords: [],
+        author_name: [],
+        projects: [],
+        dblpPid: '',
+        contacts: {
+            email: '',
+            github: ''
+        },
+        photos: {
+            photo_with_background: '',
+            photo_without_background: ''
+        }
+    };
+}
+
+export default {
+    name: 'AdminPeople',
+
+    data() {
+        return {
+            members: [],
+            form: emptyMember(),
+            researchKeywordsInput: '',
+            authorNamesInput: '',
+            projectsInput: '',
+            isCreating: true,
+            isSaving: false,
+            statusMessage: '',
+            errorMessage: ''
+        };
+    },
+
+    async created() {
+        await this.loadMembers();
+    },
+
+    methods: {
+        async loadMembers() {
+            this.members = await MembersResource.getAdminMembers();
+        },
+
+        startCreate() {
+            this.form = emptyMember();
+            this.researchKeywordsInput = '';
+            this.authorNamesInput = '';
+            this.projectsInput = '';
+            this.isCreating = true;
+            this.statusMessage = '';
+            this.errorMessage = '';
+        },
+
+        selectMember(member) {
+            this.form = JSON.parse(JSON.stringify(member));
+            this.researchKeywordsInput = (member.research_keywords || []).join(', ');
+            this.authorNamesInput = (member.author_name || []).join(', ');
+            this.projectsInput = (member.projects || []).join(', ');
+            this.isCreating = false;
+            this.statusMessage = '';
+            this.errorMessage = '';
+        },
+
+        async saveMember() {
+            this.isSaving = true;
+            this.statusMessage = '';
+            this.errorMessage = '';
+
+            try {
+                const payload = {
+                    ...this.form,
+                    research_keywords: this.researchKeywordsInput.split(',').map((item) => item.trim()).filter(Boolean),
+                    author_name: this.authorNamesInput.split(',').map((item) => item.trim()).filter(Boolean),
+                    projects: this.projectsInput.split(',').map((item) => item.trim()).filter(Boolean)
+                };
+
+                const savedMember = await MembersResource.upsertMember(payload);
+                await this.loadMembers();
+                this.selectMember(savedMember);
+                this.statusMessage = 'Person saved.';
+            } catch (error) {
+                this.errorMessage = error.message || 'Unable to save the person.';
+            } finally {
+                this.isSaving = false;
+            }
+        },
+
+        async removeMember() {
+            if (!this.form.slug) {
+                return;
+            }
+
+            try {
+                await MembersResource.deleteMember(this.form.slug);
+                await this.loadMembers();
+                this.startCreate();
+                this.statusMessage = 'Person deleted.';
+            } catch (error) {
+                this.errorMessage = error.message || 'Unable to delete the person.';
+            }
+        }
+    }
+}
+</script>
+
+<style scoped>
+.admin_page {
+    display: grid;
+    grid-template-columns: minmax(300px, 420px) minmax(0, 1fr);
+    gap: 20px;
+}
+
+.panel {
+    background: white;
+    border-radius: 24px;
+    padding: 24px;
+    box-shadow: 0 16px 36px rgba(31, 42, 61, 0.08);
+}
+
+.panel_header,
+.action_row,
+.two_col {
+    display: flex;
+    gap: 12px;
+}
+
+.panel_header,
+.action_row {
+    justify-content: space-between;
+    align-items: center;
+}
+
+.editor_form {
+    display: grid;
+    gap: 14px;
+}
+
+.two_col > label {
+    flex: 1;
+}
+
+label {
+    display: grid;
+    gap: 8px;
+}
+
+input,
+textarea,
+button {
+    font: inherit;
+}
+
+input,
+textarea {
+    border: 1px solid #c9d3df;
+    border-radius: 14px;
+    padding: 12px 14px;
+}
+
+button {
+    min-height: 44px;
+    border: 0;
+    border-radius: 999px;
+    padding: 0 16px;
+    background: #3c485e;
+    color: white;
+    cursor: pointer;
+}
+
+.secondary {
+    background: #8a2d24;
+}
+
+.row_button {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    text-align: left;
+    background: #f5f8fb;
+    color: black;
+    border-radius: 18px;
+    margin-bottom: 10px;
+    padding: 14px 16px;
+}
+
+.table_like {
+    margin-top: 18px;
+}
+
+.status {
+    background: #e6f4ea;
+    color: #24613f;
+    border-radius: 14px;
+    padding: 12px 14px;
+    margin-top: 14px;
+}
+
+.status.error {
+    background: #ffe9e7;
+    color: #8a2d24;
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: #6b7586;
+    margin-bottom: 8px;
+}
+
+@media (max-width: 980px) {
+    .admin_page {
+        grid-template-columns: 1fr;
+    }
+
+    .two_col {
+        flex-direction: column;
+    }
+}
+</style>

--- a/src/views/admin/AdminPeople.vue
+++ b/src/views/admin/AdminPeople.vue
@@ -68,7 +68,7 @@
                 </label>
 
                 <label>
-                    Research keywords
+                    Research areas
                     <input v-model="researchKeywordsInput" placeholder="comma, separated, keywords">
                 </label>
 

--- a/src/views/admin/AdminPeople.vue
+++ b/src/views/admin/AdminPeople.vue
@@ -13,9 +13,14 @@
             <p v-if="statusMessage" class="status">{{ statusMessage }}</p>
             <p v-if="errorMessage" class="status error">{{ errorMessage }}</p>
 
+            <label class="search_field">
+                Search people names
+                <input v-model="searchTerm" placeholder="Search by first or last name...">
+            </label>
+
             <div class="table_like">
                 <button
-                    v-for="member in members"
+                    v-for="member in filteredMembers"
                     :key="member.slug"
                     class="row_button"
                     @click="selectMember(member)"
@@ -212,6 +217,7 @@ export default {
     data() {
         return {
             members: [],
+            searchTerm: '',
             form: emptyMember(),
             researchKeywordsInput: '',
             authorNamesInput: '',
@@ -232,6 +238,19 @@ export default {
     },
 
     computed: {
+        filteredMembers() {
+            const normalizedSearch = this.searchTerm.trim().toLowerCase();
+
+            if (!normalizedSearch) {
+                return this.members;
+            }
+
+            return this.members.filter((member) => {
+                const fullName = `${member.firstName || ''} ${member.lastName || ''}`.trim().toLowerCase();
+                return fullName.includes(normalizedSearch);
+            });
+        },
+
         photoPreviewUrls() {
             return {
                 photo_with_background: resolveMemberImageUrl(this.form.photos.photo_with_background),
@@ -521,6 +540,10 @@ button {
     letter-spacing: 0.12em;
     color: #6b7586;
     margin-bottom: 8px;
+}
+
+.search_field {
+    margin-top: 18px;
 }
 
 .upload_inputs,

--- a/src/views/admin/AdminPeople.vue
+++ b/src/views/admin/AdminPeople.vue
@@ -53,7 +53,7 @@
                 <div class="two_col">
                     <label>
                         Slug
-                        <input v-model="form.slug" required>
+                        <input :value="derivedSlug" disabled readonly>
                     </label>
 
                     <label>
@@ -211,6 +211,12 @@ function emptyMember() {
     };
 }
 
+function slugifyName(firstName, lastName) {
+    return `${firstName || ''} ${lastName || ''}`
+        .trim()
+        .replace(/\s+/g, '-');
+}
+
 export default {
     name: 'AdminPeople',
 
@@ -218,6 +224,7 @@ export default {
         return {
             members: [],
             searchTerm: '',
+            originalSlug: '',
             form: emptyMember(),
             researchKeywordsInput: '',
             authorNamesInput: '',
@@ -238,6 +245,10 @@ export default {
     },
 
     computed: {
+        derivedSlug() {
+            return slugifyName(this.form.firstName, this.form.lastName);
+        },
+
         filteredMembers() {
             const normalizedSearch = this.searchTerm.trim().toLowerCase();
 
@@ -275,6 +286,8 @@ export default {
 
         startCreate() {
             this.form = emptyMember();
+            this.form.slug = '';
+            this.originalSlug = '';
             this.researchKeywordsInput = '';
             this.authorNamesInput = '';
             this.projectsInput = '';
@@ -294,6 +307,8 @@ export default {
 
         selectMember(member) {
             this.form = JSON.parse(JSON.stringify(member));
+            this.form.slug = slugifyName(member.firstName, member.lastName);
+            this.originalSlug = member.slug;
             this.researchKeywordsInput = (member.research_keywords || []).join(', ');
             this.authorNamesInput = (member.author_name || []).join(', ');
             this.projectsInput = (member.projects || []).join(', ');
@@ -336,7 +351,9 @@ export default {
                 return;
             }
 
-            if (!this.form.slug?.trim()) {
+            const memberSlug = this.derivedSlug.trim();
+
+            if (!memberSlug) {
                 this.errorMessage = 'Add the member slug before uploading an image so the file can be organized correctly.';
                 return;
             }
@@ -348,7 +365,7 @@ export default {
             this.errorMessage = '';
 
             try {
-                const { filePath } = await MembersResource.uploadMemberImage(selectedFile, this.form.slug, photoVariant);
+                const { filePath } = await MembersResource.uploadMemberImage(selectedFile, memberSlug, photoVariant);
                 this.form.photos = {
                     ...this.form.photos,
                     [photoVariant]: filePath
@@ -398,12 +415,15 @@ export default {
 
                 const payload = {
                     ...this.form,
+                    slug: this.derivedSlug,
                     research_keywords: this.researchKeywordsInput.split(',').map((item) => item.trim()).filter(Boolean),
                     author_name: this.authorNamesInput.split(',').map((item) => item.trim()).filter(Boolean),
                     projects: this.projectsInput.split(',').map((item) => item.trim()).filter(Boolean)
                 };
 
-                const savedMember = await MembersResource.upsertMember(payload);
+                const savedMember = this.isCreating
+                    ? await MembersResource.upsertMember(payload)
+                    : await MembersResource.updateMember(this.originalSlug || payload.slug, payload);
                 await this.loadMembers();
                 this.selectMember(savedMember);
                 this.statusMessage = 'Person saved.';
@@ -415,12 +435,14 @@ export default {
         },
 
         async removeMember() {
-            if (!this.form.slug) {
+            const memberSlug = this.form.slug || this.derivedSlug;
+
+            if (!memberSlug) {
                 return;
             }
 
             try {
-                await MembersResource.deleteMember(this.form.slug);
+                await MembersResource.deleteMember(memberSlug);
                 await this.loadMembers();
                 this.startCreate();
                 this.statusMessage = 'Person deleted.';

--- a/src/views/admin/AdminPeople.vue
+++ b/src/views/admin/AdminPeople.vue
@@ -59,7 +59,7 @@
 
                 <label>
                     Bio / description
-                    <textarea v-model="form.description" rows="6"></textarea>
+                    <textarea v-model="form.description" placeholder="Write using raw text..." rows="6"></textarea>
                 </label>
 
                 <label>
@@ -89,22 +89,88 @@
                     </label>
                 </div>
 
+                <div class="two_col upload_inputs">
+                    <label>
+                        Upload with background
+                        <input
+                            ref="backgroundPhotoInput"
+                            type="file"
+                            accept="image/*"
+                            @change="handlePhotoSelection($event, 'photo_with_background')"
+                        >
+                    </label>
+
+                    <label>
+                        Upload without background
+                        <input
+                            ref="transparentPhotoInput"
+                            type="file"
+                            accept="image/*"
+                            @change="handlePhotoSelection($event, 'photo_without_background')"
+                        >
+                    </label>
+                </div>
+
+                <div class="two_col upload_row">
+                    <div>
+                        <button
+                            type="button"
+                            class="tertiary"
+                            :disabled="!selectedPhotoFiles.photo_with_background || isUploadingPhotos.photo_with_background"
+                            @click="uploadSelectedPhoto('photo_with_background')"
+                        >
+                            {{ isUploadingPhotos.photo_with_background ? 'Uploading...' : 'Upload with background' }}
+                        </button>
+                        <p v-if="selectedPhotoFiles.photo_with_background" class="file_name">{{ selectedPhotoFiles.photo_with_background.name }}</p>
+                    </div>
+
+                    <div>
+                        <button
+                            type="button"
+                            class="tertiary"
+                            :disabled="!selectedPhotoFiles.photo_without_background || isUploadingPhotos.photo_without_background"
+                            @click="uploadSelectedPhoto('photo_without_background')"
+                        >
+                            {{ isUploadingPhotos.photo_without_background ? 'Uploading...' : 'Upload without background' }}
+                        </button>
+                        <p v-if="selectedPhotoFiles.photo_without_background" class="file_name">{{ selectedPhotoFiles.photo_without_background.name }}</p>
+                    </div>
+                </div>
+
+                <p class="help_text">
+                    Uploaded profile images are stored in the Supabase Storage bucket `people-images` and their path is filled in automatically.
+                </p>
+
+                <div class="two_col preview_grid">
+                    <div v-if="photoPreviewUrls.photo_with_background" class="image_preview">
+                        <img :src="photoPreviewUrls.photo_with_background" alt="Photo with background preview">
+                    </div>
+
+                    <div v-if="photoPreviewUrls.photo_without_background" class="image_preview">
+                        <img :src="photoPreviewUrls.photo_without_background" alt="Photo without background preview">
+                    </div>
+                </div>
+
                 <div class="two_col">
                     <label>
                         Photo with background
-                        <input v-model="form.photos.photo_with_background">
+                        <input v-model="form.photos.photo_with_background" placeholder="images/people/member/image_with_background.png or people-images/member/file.png">
                     </label>
 
                     <label>
                         Photo without background
-                        <input v-model="form.photos.photo_without_background">
+                        <input v-model="form.photos.photo_without_background" placeholder="images/people/member/image_without_background.png or people-images/member/file.png">
                     </label>
                 </div>
 
                 <label>
                     DBLP PID
-                    <input v-model="form.dblpPid">
+                    <input v-model="form.dblpPid" placeholder="">
                 </label>
+
+                <p class="help_text">
+                    DBLP.org shows the PID in the URL for any author. For example, Igor's PID would be 70/3474, as his URL is https://dblp.org/pid/70/3474.html.
+                </p>
 
                 <div class="action_row">
                     <button type="submit">{{ isSaving ? 'Saving...' : 'Save' }}</button>
@@ -116,7 +182,7 @@
 </template>
 
 <script>
-import MembersResource from '../../api/resource/people';
+import MembersResource, { resolveMemberImageUrl } from '../../api/resource/people';
 
 function emptyMember() {
     return {
@@ -152,9 +218,26 @@ export default {
             projectsInput: '',
             isCreating: true,
             isSaving: false,
+            isUploadingPhotos: {
+                photo_with_background: false,
+                photo_without_background: false
+            },
+            selectedPhotoFiles: {
+                photo_with_background: null,
+                photo_without_background: null
+            },
             statusMessage: '',
             errorMessage: ''
         };
+    },
+
+    computed: {
+        photoPreviewUrls() {
+            return {
+                photo_with_background: resolveMemberImageUrl(this.form.photos.photo_with_background),
+                photo_without_background: resolveMemberImageUrl(this.form.photos.photo_without_background)
+            };
+        }
     },
 
     async created() {
@@ -163,7 +246,12 @@ export default {
 
     methods: {
         async loadMembers() {
-            this.members = await MembersResource.getAdminMembers();
+            try {
+                this.members = await MembersResource.getAdminMembers();
+            } catch (error) {
+                this.members = [];
+                this.errorMessage = error.message || 'Unable to load people.';
+            }
         },
 
         startCreate() {
@@ -174,6 +262,15 @@ export default {
             this.isCreating = true;
             this.statusMessage = '';
             this.errorMessage = '';
+            this.selectedPhotoFiles = {
+                photo_with_background: null,
+                photo_without_background: null
+            };
+            this.isUploadingPhotos = {
+                photo_with_background: false,
+                photo_without_background: false
+            };
+            this.clearPhotoInputs();
         },
 
         selectMember(member) {
@@ -184,6 +281,82 @@ export default {
             this.isCreating = false;
             this.statusMessage = '';
             this.errorMessage = '';
+            this.selectedPhotoFiles = {
+                photo_with_background: null,
+                photo_without_background: null
+            };
+            this.isUploadingPhotos = {
+                photo_with_background: false,
+                photo_without_background: false
+            };
+            this.clearPhotoInputs();
+        },
+
+        clearPhotoInputs() {
+            if (this.$refs.backgroundPhotoInput) {
+                this.$refs.backgroundPhotoInput.value = '';
+            }
+
+            if (this.$refs.transparentPhotoInput) {
+                this.$refs.transparentPhotoInput.value = '';
+            }
+        },
+
+        handlePhotoSelection(event, photoVariant) {
+            const [file] = event.target.files || [];
+            this.selectedPhotoFiles = {
+                ...this.selectedPhotoFiles,
+                [photoVariant]: file || null
+            };
+        },
+
+        async uploadSelectedPhoto(photoVariant, options = {}) {
+            const selectedFile = this.selectedPhotoFiles[photoVariant];
+
+            if (!selectedFile) {
+                return;
+            }
+
+            if (!this.form.slug?.trim()) {
+                this.errorMessage = 'Add the member slug before uploading an image so the file can be organized correctly.';
+                return;
+            }
+
+            this.isUploadingPhotos = {
+                ...this.isUploadingPhotos,
+                [photoVariant]: true
+            };
+            this.errorMessage = '';
+
+            try {
+                const { filePath } = await MembersResource.uploadMemberImage(selectedFile, this.form.slug, photoVariant);
+                this.form.photos = {
+                    ...this.form.photos,
+                    [photoVariant]: filePath
+                };
+                this.selectedPhotoFiles = {
+                    ...this.selectedPhotoFiles,
+                    [photoVariant]: null
+                };
+
+                const inputRef = photoVariant === 'photo_with_background' ? 'backgroundPhotoInput' : 'transparentPhotoInput';
+
+                if (this.$refs[inputRef]) {
+                    this.$refs[inputRef].value = '';
+                }
+
+                if (!options.preserveStatusMessage) {
+                    this.statusMessage = 'Profile image uploaded. Save the person to attach it permanently.';
+                }
+            } catch (error) {
+                this.errorMessage = error.message || 'Unable to upload the profile image.';
+                throw error;
+            } finally {
+                this.isUploadingPhotos = {
+                    ...this.isUploadingPhotos,
+                    [photoVariant]: false
+                };
+            }
         },
 
         async saveMember() {
@@ -192,6 +365,18 @@ export default {
             this.errorMessage = '';
 
             try {
+                if (this.selectedPhotoFiles.photo_with_background) {
+                    await this.uploadSelectedPhoto('photo_with_background', {
+                        preserveStatusMessage: true
+                    });
+                }
+
+                if (this.selectedPhotoFiles.photo_without_background) {
+                    await this.uploadSelectedPhoto('photo_without_background', {
+                        preserveStatusMessage: true
+                    });
+                }
+
                 const payload = {
                     ...this.form,
                     research_keywords: this.researchKeywordsInput.split(',').map((item) => item.trim()).filter(Boolean),
@@ -244,7 +429,8 @@ export default {
 
 .panel_header,
 .action_row,
-.two_col {
+.two_col,
+.upload_row {
     display: flex;
     gap: 12px;
 }
@@ -296,6 +482,10 @@ button {
     background: #8a2d24;
 }
 
+.tertiary {
+    background: #5f6b80;
+}
+
 .row_button {
     width: 100%;
     display: flex;
@@ -331,6 +521,30 @@ button {
     letter-spacing: 0.12em;
     color: #6b7586;
     margin-bottom: 8px;
+}
+
+.upload_inputs,
+.preview_grid {
+    align-items: flex-start;
+}
+
+.help_text,
+.file_name {
+    color: #6b7586;
+    font-size: 0.95rem;
+}
+
+.image_preview {
+    background: #f5f8fb;
+    border-radius: 18px;
+    padding: 12px;
+}
+
+.image_preview img {
+    width: 100%;
+    max-height: 220px;
+    object-fit: contain;
+    display: block;
 }
 
 @media (max-width: 980px) {

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,145 @@
+create table if not exists public.profiles (
+    id uuid primary key references auth.users (id) on delete cascade,
+    email text unique,
+    full_name text,
+    is_admin boolean not null default false,
+    created_at timestamp with time zone not null default timezone('utc', now())
+);
+
+create table if not exists public.news_posts (
+    id text primary key,
+    title text not null,
+    date text not null,
+    person text[] not null default '{}',
+    tag text not null default '',
+    image text not null default '',
+    description text not null default '',
+    published boolean not null default true,
+    sort_order integer,
+    created_at timestamp with time zone not null default timezone('utc', now()),
+    updated_at timestamp with time zone not null default timezone('utc', now())
+);
+
+create table if not exists public.people_profiles (
+    slug text primary key,
+    first_name text not null,
+    last_name text not null,
+    role text not null,
+    description text not null default '',
+    contacts jsonb not null default '{}'::jsonb,
+    photos jsonb not null default '{}'::jsonb,
+    research_keywords text[] not null default '{}',
+    highlighted_publications text[] not null default '{}',
+    author_name text[] not null default '{}',
+    dblp_pid text not null default '',
+    projects text[] not null default '{}',
+    is_active boolean not null default true,
+    created_at timestamp with time zone not null default timezone('utc', now()),
+    updated_at timestamp with time zone not null default timezone('utc', now())
+);
+
+create or replace function public.handle_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+    new.updated_at = timezone('utc', now());
+    return new;
+end;
+$$;
+
+drop trigger if exists set_news_posts_updated_at on public.news_posts;
+create trigger set_news_posts_updated_at
+before update on public.news_posts
+for each row execute function public.handle_updated_at();
+
+drop trigger if exists set_people_profiles_updated_at on public.people_profiles;
+create trigger set_people_profiles_updated_at
+before update on public.people_profiles
+for each row execute function public.handle_updated_at();
+
+alter table public.profiles enable row level security;
+alter table public.news_posts enable row level security;
+alter table public.people_profiles enable row level security;
+
+create policy "public can read published news"
+on public.news_posts
+for select
+using (published = true);
+
+create policy "public can read active people"
+on public.people_profiles
+for select
+using (is_active = true);
+
+create policy "admins can read profiles"
+on public.profiles
+for select
+to authenticated
+using (auth.uid() = id);
+
+create policy "admins can manage news"
+on public.news_posts
+for all
+to authenticated
+using (
+    exists (
+        select 1
+        from public.profiles
+        where profiles.id = auth.uid()
+        and profiles.is_admin = true
+    )
+)
+with check (
+    exists (
+        select 1
+        from public.profiles
+        where profiles.id = auth.uid()
+        and profiles.is_admin = true
+    )
+);
+
+create policy "admins can manage people"
+on public.people_profiles
+for all
+to authenticated
+using (
+    exists (
+        select 1
+        from public.profiles
+        where profiles.id = auth.uid()
+        and profiles.is_admin = true
+    )
+)
+with check (
+    exists (
+        select 1
+        from public.profiles
+        where profiles.id = auth.uid()
+        and profiles.is_admin = true
+    )
+);
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    insert into public.profiles (id, email, full_name, is_admin)
+    values (
+        new.id,
+        new.email,
+        coalesce(new.raw_user_meta_data ->> 'full_name', ''),
+        false
+    )
+    on conflict (id) do nothing;
+    return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+after insert on auth.users
+for each row execute procedure public.handle_new_user();

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -38,6 +38,14 @@ create table if not exists public.people_profiles (
     updated_at timestamp with time zone not null default timezone('utc', now())
 );
 
+insert into storage.buckets (id, name, public)
+values ('news-images', 'news-images', true)
+on conflict (id) do nothing;
+
+insert into storage.buckets (id, name, public)
+values ('people-images', 'people-images', true)
+on conflict (id) do nothing;
+
 create or replace function public.handle_updated_at()
 returns trigger
 language plpgsql
@@ -62,24 +70,50 @@ alter table public.profiles enable row level security;
 alter table public.news_posts enable row level security;
 alter table public.people_profiles enable row level security;
 
+drop policy if exists "public can read published news" on public.news_posts;
 create policy "public can read published news"
 on public.news_posts
 for select
 using (published = true);
 
+drop policy if exists "public can read active people" on public.people_profiles;
 create policy "public can read active people"
 on public.people_profiles
 for select
 using (is_active = true);
 
+drop policy if exists "admins can read profiles" on public.profiles;
 create policy "admins can read profiles"
 on public.profiles
 for select
 to authenticated
 using (auth.uid() = id);
 
+drop policy if exists "admins can manage news" on public.news_posts;
 create policy "admins can manage news"
 on public.news_posts
+for all
+to authenticated
+using (
+    exists (
+        select 1
+        from public.profiles
+        where profiles.id = auth.uid()
+        and profiles.is_admin = true
+    )
+)
+with check (
+    exists (
+        select 1
+        from public.profiles
+        where profiles.id = auth.uid()
+        and profiles.is_admin = true
+	    )
+	);
+
+drop policy if exists "admins can manage people" on public.people_profiles;
+create policy "admins can manage people"
+on public.people_profiles
 for all
 to authenticated
 using (
@@ -99,12 +133,35 @@ with check (
     )
 );
 
-create policy "admins can manage people"
-on public.people_profiles
-for all
+drop policy if exists "public can read news images" on storage.objects;
+create policy "public can read news images"
+on storage.objects
+for select
+using (bucket_id = 'news-images');
+
+drop policy if exists "admins can upload news images" on storage.objects;
+create policy "admins can upload news images"
+on storage.objects
+for insert
+to authenticated
+with check (
+    bucket_id = 'news-images'
+    and exists (
+        select 1
+        from public.profiles
+        where profiles.id = auth.uid()
+        and profiles.is_admin = true
+    )
+);
+
+drop policy if exists "admins can update news images" on storage.objects;
+create policy "admins can update news images"
+on storage.objects
+for update
 to authenticated
 using (
-    exists (
+    bucket_id = 'news-images'
+    and exists (
         select 1
         from public.profiles
         where profiles.id = auth.uid()
@@ -112,7 +169,83 @@ using (
     )
 )
 with check (
-    exists (
+    bucket_id = 'news-images'
+    and exists (
+        select 1
+        from public.profiles
+        where profiles.id = auth.uid()
+        and profiles.is_admin = true
+    )
+);
+
+drop policy if exists "admins can delete news images" on storage.objects;
+create policy "admins can delete news images"
+on storage.objects
+for delete
+to authenticated
+using (
+    bucket_id = 'news-images'
+    and exists (
+        select 1
+        from public.profiles
+        where profiles.id = auth.uid()
+        and profiles.is_admin = true
+    )
+);
+
+drop policy if exists "public can read people images" on storage.objects;
+create policy "public can read people images"
+on storage.objects
+for select
+using (bucket_id = 'people-images');
+
+drop policy if exists "admins can upload people images" on storage.objects;
+create policy "admins can upload people images"
+on storage.objects
+for insert
+to authenticated
+with check (
+    bucket_id = 'people-images'
+    and exists (
+        select 1
+        from public.profiles
+        where profiles.id = auth.uid()
+        and profiles.is_admin = true
+    )
+);
+
+drop policy if exists "admins can update people images" on storage.objects;
+create policy "admins can update people images"
+on storage.objects
+for update
+to authenticated
+using (
+    bucket_id = 'people-images'
+    and exists (
+        select 1
+        from public.profiles
+        where profiles.id = auth.uid()
+        and profiles.is_admin = true
+    )
+)
+with check (
+    bucket_id = 'people-images'
+    and exists (
+        select 1
+        from public.profiles
+        where profiles.id = auth.uid()
+        and profiles.is_admin = true
+    )
+);
+
+drop policy if exists "admins can delete people images" on storage.objects;
+create policy "admins can delete people images"
+on storage.objects
+for delete
+to authenticated
+using (
+    bucket_id = 'people-images'
+    and exists (
         select 1
         from public.profiles
         where profiles.id = auth.uid()


### PR DESCRIPTION
This application can now support full CRUD functionality with People and News posts. Current people and news data stored in the json, along with related images, can be automatically moved to your Supabase project as well. My next steps are to create a "Projects" page and add more CRUD functionality for other json data contained in the project, like funding, research areas, etc.

Please read more in the updated README.md, which will be pasted here for your convenience:

# reshapelab.github.io
Project Page

## Supabase Admin

This repo now includes a Supabase-backed admin portal for:

1. Admin login at `/admin/login`
2. News CRUD at `/admin/news`
3. People CRUD at `/admin/people`
4. Editing research keywords, DBLP PIDs, and profile metadata for people

### Setup

1. Create a Supabase project.
2. Run the SQL in [supabase/schema.sql](./supabase/schema.sql) in the Supabase SQL editor.
3. Create a `.env` file and fill in these values after the "=" using your Supabase API keys.
   - `VITE_SUPABASE_URL=`
   - `VITE_SUPABASE_ANON_KEY=`
   - `SUPABASE_SERVICE_ROLE_KEY=`
4. In Supabase Auth, enable Email/Password login (it may already be enabled).
5. Create your first user in Supabase Auth.
6. In the `profiles` table, set that user's `is_admin` to `true`. This user may now use the admin portal for the website.

### Notes

- The public site still falls back to the local .json files when Supabase is not configured or unavailable.
- News images and profile images are still stored as string paths.
- The current .json and image data can be uploaded to Supabase at anytime (as long as .env is configured) using `npm run import:supabase`
- Test this project by first using `npm i` then `npm run dev`
